### PR TITLE
Revert remove targeted product

### DIFF
--- a/create-jira-release-ticket/README.md
+++ b/create-jira-release-ticket/README.md
@@ -20,6 +20,7 @@ The following inputs can be configured for the action:
 | `project_name`         | The display name of the project (e.g., `SonarIaC`). Will be used as the prefix of the resulting release ticket.    | `true`   |         |
 | `version`              | The new version string being released (e.g., `1.2.3`).                                                             | `true`   |         |
 | `short_description`    | A brief description of the release.                                                                                | `true`   |         |
+| `targeted_product`     | The targeted product version (e.g., `11.0`).                                                                       | `true`   |         |
 | `sq_compatibility`     | The SonarQube compatibility version (e.g., `2025.3`).                                                              | `true`   |         |
 | `use_sandbox`          | Set to `false` to use the Jira production server.                                                                  | `false`  | `true`  |
 | `documentation_status` | The status of the release documentation.                                                                           | `false`  | `N/A`   |
@@ -40,6 +41,7 @@ Here is an example of how to use this action in a workflow. This job will be tri
 ```yaml
 name: Create Release Ticket
 
+# Define environment variables for project-specific settings
 env:
   PROJECT_KEY: 'SONARIAC'
   PROJECT_NAME: 'SonarIaC'
@@ -54,10 +56,13 @@ on:
       short_description:
         description: 'Short Description'
         required: true
+      targeted_product:
+        description: 'Targeted Product'
+        required: true
       sq_compatibility:
         description: 'SonarQube Compatibility'
         required: true
-      jira_release_name:
+      jira_release:
         description: 'Jira release version'
         required: false
       sonarlint_changelog:
@@ -91,6 +96,7 @@ jobs:
           project_name: ${{ env.PROJECT_NAME }}
           version: ${{ github.event.inputs.version }}
           short_description: ${{ github.event.inputs.short_description }}
+          targeted_product: ${{ github.event.inputs.targeted_product }}
           sq_compatibility: ${{ github.event.inputs.sq_compatibility }}
           jira_release_name: ${{ github.event.inputs.jira_release }}
           sonarlint_changelog: ${{ github.event.inputs.sonarlint_changelog }}

--- a/create-jira-release-ticket/README.md
+++ b/create-jira-release-ticket/README.md
@@ -41,7 +41,6 @@ Here is an example of how to use this action in a workflow. This job will be tri
 ```yaml
 name: Create Release Ticket
 
-# Define environment variables for project-specific settings
 env:
   PROJECT_KEY: 'SONARIAC'
   PROJECT_NAME: 'SonarIaC'
@@ -56,13 +55,13 @@ on:
       short_description:
         description: 'Short Description'
         required: true
-      targeted_product:
-        description: 'Targeted Product'
-        required: true
       sq_compatibility:
         description: 'SonarQube Compatibility'
         required: true
-      jira_release:
+      targeted_product:
+        description: 'Targeted Product'
+        required: false
+      jira_release_name:
         description: 'Jira release version'
         required: false
       sonarlint_changelog:

--- a/create-jira-release-ticket/README.md
+++ b/create-jira-release-ticket/README.md
@@ -20,8 +20,8 @@ The following inputs can be configured for the action:
 | `project_name`         | The display name of the project (e.g., `SonarIaC`). Will be used as the prefix of the resulting release ticket.    | `true`   |         |
 | `version`              | The new version string being released (e.g., `1.2.3`).                                                             | `true`   |         |
 | `short_description`    | A brief description of the release.                                                                                | `true`   |         |
-| `targeted_product`     | The targeted product version (e.g., `11.0`).                                                                       | `true`   |         |
 | `sq_compatibility`     | The SonarQube compatibility version (e.g., `2025.3`).                                                              | `true`   |         |
+| `targeted_product`     | The targeted product version (e.g., `11.0`).                                                                       | `false`  |         |
 | `use_sandbox`          | Set to `false` to use the Jira production server.                                                                  | `false`  | `true`  |
 | `documentation_status` | The status of the release documentation.                                                                           | `false`  | `N/A`   |
 | `rule_props_changed`   | Whether rule properties have changed (`Yes` or `No`).                                                              | `false`  | `No`    |

--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: true
   targeted_product:
     description: 'The targeted product version (e.g., 11.0)'
-    required: true
+    required: false
   sq_compatibility:
     description: 'SonarQube compatibility version (e.g., 2025.3)'
     required: true

--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -21,6 +21,9 @@ inputs:
   short_description:
     description: 'A short description for the release'
     required: true
+  targeted_product:
+    description: 'The targeted product version (e.g., 11.0)'
+    required: true
   sq_compatibility:
     description: 'SonarQube compatibility version (e.g., 2025.3)'
     required: true
@@ -76,6 +79,7 @@ runs:
           --project-name="${{ inputs.project_name }}" \
           --version="${{ inputs.version }}" \
           --short-description="${{ inputs.short_description }}" \
+          --targeted-product="${{ inputs.targeted_product }}" \
           --sq-compatibility="${{ inputs.sq_compatibility }}" \
           ${SANDBOX_FLAG} \
           --documentation-status="${{ inputs.documentation_status }}" \

--- a/create-jira-release-ticket/create_release_ticket.py
+++ b/create-jira-release-ticket/create_release_ticket.py
@@ -158,12 +158,14 @@ def create_release_ticket(jira_client, args, link_to_release_notes):
         'summary': f'{args.project_name} {args.version}',
         CUSTOM_FIELDS['SHORT_DESCRIPTION']: args.short_description,
         CUSTOM_FIELDS['SQ_COMPATIBILITY']: args.sq_compatibility,
-        CUSTOM_FIELDS['TARGETED_PRODUCT']: {'value': args.targeted_product},
         CUSTOM_FIELDS['LINK_TO_RELEASE_NOTES']: link_to_release_notes,
         CUSTOM_FIELDS['DOCUMENTATION_STATUS']: args.documentation_status,
         CUSTOM_FIELDS['RULE_PROPS_CHANGED']: {'value': args.rule_props_changed},
         CUSTOM_FIELDS['SONARLINT_CHANGELOG']: args.sonarlint_changelog
     }
+
+    if args.targeted_product:
+        ticket_details[CUSTOM_FIELDS['TARGETED_PRODUCT']] = {'value': args.targeted_product}
 
     try:
         new_ticket = jira_client.create_issue(fields=ticket_details)
@@ -188,7 +190,7 @@ def main():
     parser.add_argument("--version", required=True, help="The version being released (e.g., 11.44.2).")
     parser.add_argument("--short-description", required=True, help="A short description for the release.")
     parser.add_argument("--sq-compatibility", required=True, help="SonarQube compatibility version (e.g., 2025.3).")
-    parser.add_argument("--targeted-product", required=False, help="The targeted product version (e.g., 11.0).")
+    parser.add_argument("--targeted-product", help="The targeted product version (e.g., 11.0).")
     parser.add_argument('--use-sandbox', action='store_true', help="Use the sandbox server instead of the production Jira.")
     parser.add_argument("--documentation-status", default="N/A", help="Status of the documentation.")
     parser.add_argument("--rule-props-changed", default="No", choices=['Yes', 'No'],

--- a/create-jira-release-ticket/create_release_ticket.py
+++ b/create-jira-release-ticket/create_release_ticket.py
@@ -16,8 +16,8 @@ JIRA_SANDBOX_URL = "https://sonarsource-sandbox-608.atlassian.net/"
 JIRA_PROD_URL = "https://sonarsource.atlassian.net/"
 CUSTOM_FIELDS = {
     'SHORT_DESCRIPTION': 'customfield_10146',
-    'TARGETED_PRODUCT': 'customfield_10163',
     'SQ_COMPATIBILITY': 'customfield_10148',
+    'TARGETED_PRODUCT': 'customfield_10163',
     'LINK_TO_RELEASE_NOTES': 'customfield_10145',
     'DOCUMENTATION_STATUS': 'customfield_10147',
     'RULE_PROPS_CHANGED': 'customfield_11263',
@@ -157,8 +157,8 @@ def create_release_ticket(jira_client, args, link_to_release_notes):
         'issuetype': 'Ask for release',
         'summary': f'{args.project_name} {args.version}',
         CUSTOM_FIELDS['SHORT_DESCRIPTION']: args.short_description,
-        CUSTOM_FIELDS['TARGETED_PRODUCT']: {'value': args.targeted_product},
         CUSTOM_FIELDS['SQ_COMPATIBILITY']: args.sq_compatibility,
+        CUSTOM_FIELDS['TARGETED_PRODUCT']: {'value': args.targeted_product},
         CUSTOM_FIELDS['LINK_TO_RELEASE_NOTES']: link_to_release_notes,
         CUSTOM_FIELDS['DOCUMENTATION_STATUS']: args.documentation_status,
         CUSTOM_FIELDS['RULE_PROPS_CHANGED']: {'value': args.rule_props_changed},
@@ -187,8 +187,8 @@ def main():
     parser.add_argument("--project-name", required=True, help="The display name of the project (e.g., SonarIaC).")
     parser.add_argument("--version", required=True, help="The version being released (e.g., 11.44.2).")
     parser.add_argument("--short-description", required=True, help="A short description for the release.")
-    parser.add_argument("--targeted-product", required=True, help="The targeted product version (e.g., 11.0).")
     parser.add_argument("--sq-compatibility", required=True, help="SonarQube compatibility version (e.g., 2025.3).")
+    parser.add_argument("--targeted-product", required=False, help="The targeted product version (e.g., 11.0).")
     parser.add_argument('--use-sandbox', action='store_true', help="Use the sandbox server instead of the production Jira.")
     parser.add_argument("--documentation-status", default="N/A", help="Status of the documentation.")
     parser.add_argument("--rule-props-changed", default="No", choices=['Yes', 'No'],

--- a/create-jira-release-ticket/create_release_ticket.py
+++ b/create-jira-release-ticket/create_release_ticket.py
@@ -16,6 +16,7 @@ JIRA_SANDBOX_URL = "https://sonarsource-sandbox-608.atlassian.net/"
 JIRA_PROD_URL = "https://sonarsource.atlassian.net/"
 CUSTOM_FIELDS = {
     'SHORT_DESCRIPTION': 'customfield_10146',
+    'TARGETED_PRODUCT': 'customfield_10163',
     'SQ_COMPATIBILITY': 'customfield_10148',
     'LINK_TO_RELEASE_NOTES': 'customfield_10145',
     'DOCUMENTATION_STATUS': 'customfield_10147',
@@ -156,6 +157,7 @@ def create_release_ticket(jira_client, args, link_to_release_notes):
         'issuetype': 'Ask for release',
         'summary': f'{args.project_name} {args.version}',
         CUSTOM_FIELDS['SHORT_DESCRIPTION']: args.short_description,
+        CUSTOM_FIELDS['TARGETED_PRODUCT']: {'value': args.targeted_product},
         CUSTOM_FIELDS['SQ_COMPATIBILITY']: args.sq_compatibility,
         CUSTOM_FIELDS['LINK_TO_RELEASE_NOTES']: link_to_release_notes,
         CUSTOM_FIELDS['DOCUMENTATION_STATUS']: args.documentation_status,
@@ -185,6 +187,7 @@ def main():
     parser.add_argument("--project-name", required=True, help="The display name of the project (e.g., SonarIaC).")
     parser.add_argument("--version", required=True, help="The version being released (e.g., 11.44.2).")
     parser.add_argument("--short-description", required=True, help="A short description for the release.")
+    parser.add_argument("--targeted-product", required=True, help="The targeted product version (e.g., 11.0).")
     parser.add_argument("--sq-compatibility", required=True, help="SonarQube compatibility version (e.g., 2025.3).")
     parser.add_argument('--use-sandbox', action='store_true', help="Use the sandbox server instead of the production Jira.")
     parser.add_argument("--documentation-status", default="N/A", help="Status of the documentation.")


### PR DESCRIPTION
After removing targeted product with this PR: https://github.com/SonarSource/release-github-actions/pull/5 I realized that even though it's deprecated we would need to set it for now in order to triger the jira automation that creates the SQS ticket