### PR TITLE
Add environment variable setup for Jira release details

### DIFF
--- a/create-jira-release-ticket/README.md
+++ b/create-jira-release-ticket/README.md
@@ -38,6 +38,17 @@ The following inputs can be configured for the action:
 | `ticket_url`        | The URL of the created Jira ticket.              |
 | `release_url`       | The URL of the Jira release page.                |
 
+## Environment Variables
+
+The action also sets the following environment variables that can be used in subsequent workflow steps:
+
+| Variable              | Description                                      |
+|-----------------------|--------------------------------------------------|
+| `RELEASE_TICKET_KEY`  | The key of the created Jira ticket (e.g., `REL-1234`). |
+| `JIRA_RELEASE_NAME`   | The name of the Jira release used by the action. |
+| `RELEASE_TICKET_URL`  | The URL of the created Jira ticket.              |
+| `JIRA_RELEASE_URL`    | The URL of the Jira release page.                |
+
 ## Example Usage
 
 Here is an example of how to use this action in a workflow. This job will be triggered manually and will create a Jira

--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -100,3 +100,11 @@ runs:
       env:
         JIRA_USER: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_USER }}
         JIRA_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).JIRA_TOKEN }}
+
+    - name: Set Env Variables
+      shell: bash
+      run: |
+        echo "JIRA_RELEASE_NAME=${{ steps.run_python_script.outputs.jira_release_name }}" >> $GITHUB_ENV
+        echo "JIRA_RELEASE_URL=${{ steps.run_python_script.outputs.release_url }}" >> $GITHUB_ENV
+        echo "RELEASE_TICKET_KEY=${{ steps.run_python_script.outputs.ticket_key }}" >> $GITHUB_ENV
+        echo "RELEASE_TICKET_URL=${{ steps.run_python_script.outputs.ticket_url }}" >> $GITHUB_ENV


### PR DESCRIPTION
In addition to providing action results as output, we should set shared environmental variables. This allows other actions to rely on them instead of requiring additional inputs. As a result, these inputs can become optional, and we can use the environmental variable as a fallback. Overall, this simplifies the release process by combining different actions.

For example, instead of requiring `${{ needs.create_release_ticket.outputs.release_name }}` as input for the `publish-github-release` action, you can make the `release_name` input optional. If not provided, the action will use `${{ env.JIRA_RELEASE_NAME }}` as a fallback. This way, `publish-github-release` can run independently when needed, while still allowing reduced and simplified inputs when used in combination with environment variables.