### PR TITLE
Add expected_status to update-release-ticket-status

### DIFF
--- a/update-release-ticket-status/README.md
+++ b/update-release-ticket-status/README.md
@@ -11,12 +11,13 @@ portal ([more info](https://xtranet-sonarsource.atlassian.net/wiki/spaces/Platfo
 
 ## Inputs
 
-| Input         | Description                                                                     | Required | Default |
-|---------------|---------------------------------------------------------------------------------|----------|---------|
-| `ticket_key`  | The key of the Jira ticket to update (e.g., `REL-1234`).                        | `true`   |         |
-| `status`      | The target status. Possible values: `Start Progress`, `Technical Release Done`. | `true`   |         |
-| `assignee`    | The email of the user to assign the ticket to.                                  | `false`  | `''`    |
-| `use_sandbox` | Set to `true` to use the Jira sandbox server.                                   | `false`  | `false` |
+| Input             | Description                                                                                                   | Required | Default |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `ticket_key`      | The key of the Jira ticket to update (e.g., `REL-1234`).                                                      | `true`   |         |
+| `status`          | The target status. Possible values: `Start Progress`, `Technical Release Done`.                               | `true`   |         |
+| `expected_status` | The status the ticket is expected to be in before the transition. If not, the ticket will not be transitioned | `false`  | `''`    |
+| `assignee`        | The email of the user to assign the ticket to.                                                                | `false`  | `''`    |
+| `use_sandbox`     | Set to `true` to use the Jira sandbox server.                                                                 | `false`  | `false` |
 
 ## Example Usage
 

--- a/update-release-ticket-status/action.yml
+++ b/update-release-ticket-status/action.yml
@@ -9,6 +9,10 @@ inputs:
   status:
     description: 'The target status for the ticket. Must be a valid transition.'
     required: true
+  expected_status:
+    description: 'The expected status for the ticket before transitioning. If the ticket is already in this status, it will not be transitioned.'
+    required: false
+    default: ''
   assignee:
     description: 'The email of the user to assign the ticket to.'
     required: false
@@ -52,9 +56,15 @@ runs:
           ASSIGNEE_FLAG="--assignee=${{ inputs.assignee }}"
         fi
 
+        EXPECTED_STATUS_FLAG=""
+        if [[ -n "${{ inputs.expected_status }}" ]]; then
+          EXPECTED_STATUS_FLAG="--expected-status=${{ inputs.expected_status }}"
+        fi
+
         python ${{ github.action_path }}/update_release_ticket.py \
           --ticket-key="${{ inputs.ticket_key }}" \
           --status="${{ inputs.status }}" \
+          ${EXPECTED_STATUS_FLAG} \
           ${ASSIGNEE_FLAG} \
           ${SANDBOX_FLAG}
       env:


### PR DESCRIPTION
This PR adds an optional `expected_status` parameter, which controls if the specified transition should be done or not. 
This field is necessary if you want to be able to re-run the whole release workflow. Since the REL ticket would already be in the desired state, transitioning it would fail, since that specific transition wouldn't be available. 
However, if the `expected_status` is set and the current state of the issue doesn't match it, this step will be skipped