### PR TITLE
clear the GITHUB_TOKEN before gh auth login

### DIFF
--- a/publish-github-release/action.yml
+++ b/publish-github-release/action.yml
@@ -121,6 +121,8 @@ runs:
       id: create_release
       shell: bash
       run: |
+        # clear GITHUB_TOKEN for gh auth login to be happy
+        export GITHUB_TOKEN=
         echo "${{ inputs.github_token }}" | gh auth login --with-token
 
         # Check if a release with the same title already exists
@@ -178,6 +180,8 @@ runs:
     - name: Trigger Release Workflow
       shell: bash
       run: |
+        # clear GITHUB_TOKEN for gh auth login to be happy
+        export GITHUB_TOKEN=
         echo "${{ inputs.github_token }}" | gh auth login --with-token
         
         # Set release ID based on draft status


### PR DESCRIPTION
Running the workflow produced the following error for me
```
The value of the GITHUB_TOKEN environment variable is being used for authentication.
To have GitHub CLI store credentials instead, first clear the value from the environment.
```

This PR clears the `GITHUB_TOKEN` env variable first

Also, I've only have tested this, so it might be worth testing it again before merging