### PR TITLE
Fix conditional logic for Jira URL selection in release action

### DIFF
--- a/create-jira-version/action.yml
+++ b/create-jira-version/action.yml
@@ -64,5 +64,5 @@ runs:
           python ${{ github.action_path }}/create_jira_version.py \
           --project-key="${{ inputs.jira_project_key }}" \
           --version-name="${{ inputs.jira_version_name || steps.determine_version_name.outputs.VERSION_NAME }}" \
-          ${{ (inputs.use_jira_sandbox == 'true' || env.USE_JIRA_SANDBOX == 'true') && '--use-sandbox' || '' }} \
+          --jira-url="${{ ((inputs.use_jira_sandbox || env.USE_JIRA_SANDBOX) == 'true') && env.JIRA_SANDBOX_URL || env.JIRA_PROD_URL }}" 
           >> $GITHUB_OUTPUT

--- a/create-jira-version/create_jira_version.py
+++ b/create-jira-version/create_jira_version.py
@@ -16,21 +16,17 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 # noinspection DuplicatedCode
-def get_jira_instance(use_sandbox=False):
+def get_jira_instance(jira_url):
     """
     Initializes and returns a JIRA client instance.
     Authentication is handled via environment variables.
     """
     jira_user = os.environ.get('JIRA_USER')
     jira_token = os.environ.get('JIRA_TOKEN')
-    jira_prod_url = os.environ.get('JIRA_PROD_URL')
-    jira_sandbox_url = os.environ.get('JIRA_SANDBOX_URL')
 
     if not jira_user or not jira_token:
         eprint("Error: JIRA_USER and JIRA_TOKEN environment variables must be set.")
         sys.exit(1)
-
-    jira_url = jira_sandbox_url if use_sandbox else jira_prod_url
 
     eprint(f"Connecting to JIRA server at: {jira_url}")
     try:
@@ -55,10 +51,10 @@ def main():
     )
     parser.add_argument("--project-key", required=True, help="The key of the Jira project (e.g., SONARIAC).")
     parser.add_argument("--version-name", required=True, help="The name for the next version.")
-    parser.add_argument('--use-sandbox', action='store_true', help="Use the sandbox Jira server.")
+    parser.add_argument('--jira-url', required=True, help="URL of the Jira instance to use.")
     args = parser.parse_args()
 
-    jira = get_jira_instance(args.use_sandbox)
+    jira = get_jira_instance(args.jira_url)
 
     eprint(f"Try to create new version '{args.version_name}'")
     try:


### PR DESCRIPTION
This pull request refactors how the Jira server URL is selected and passed throughout the workflow and script, replacing the previous sandbox flag and environment variable logic with a direct `--jira-url` parameter. This simplifies configuration and improves clarity. The tests are updated to reflect these changes, removing sandbox-specific logic and ensuring all tests use the new URL argument.

**Jira URL handling and workflow invocation:**

* The workflow in `action.yml` now determines the Jira URL based on environment variables and passes it directly to the script as `--jira-url`, removing the previous conditional sandbox flag logic.

**Script interface and logic changes:**

* The Python script `create_jira_version.py` changes its interface to require a `--jira-url` parameter and removes all logic related to the sandbox flag and separate prod/sandbox URLs. The function `get_jira_instance` now only takes the Jira URL as an argument. [[1]](diffhunk://#diff-d0e66253162df4f9de082f48a5ea20eb2a18476f7b62fd72dbc7730a7a59cde3L19-L34) [[2]](diffhunk://#diff-d0e66253162df4f9de082f48a5ea20eb2a18476f7b62fd72dbc7730a7a59cde3L58-R57)

**Test updates and simplification:**

* All tests in `test_create_jira_version.py` are updated to use the new `--jira-url` parameter, removing sandbox-specific test cases and environment variables. Tests now directly verify that the correct URL is passed to `get_jira_instance`. [[1]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4L27-R61) [[2]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4R77-R79) [[3]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4L104-R92) [[4]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4L145-R133) [[5]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4L175-R163) [[6]](diffhunk://#diff-a8b96265867d7b5a48118fc67654da7a50001c660015d58a8dcaf2386b1479b4L198-L213)