### PR TITLE
Switch to get-release-version pt2

### DIFF
--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -63,12 +63,12 @@ runs:
       shell: bash
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
-    - uses: SonarSource/release-github-actions/get-release-version@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+    - uses: SonarSource/release-github-actions/get-release-version@6452648457a9c19d90b859faf36465af99454bc6
       if: ${{ !inputs.version }}
 
     - name: Get Jira Release Notes URL
       if: ${{ !inputs.jira-release-url && !env.JIRA_RELEASE_URL }}
-      uses: SonarSource/release-github-actions/get-jira-release-notes@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+      uses: SonarSource/release-github-actions/get-jira-release-notes@6452648457a9c19d90b859faf36465af99454bc6
       with:
         jira-project-key: ${{ inputs.jira-project-key }}
         use-jira-sandbox: ${{ inputs.use-jira-sandbox }}
@@ -104,7 +104,7 @@ runs:
 
     - name: Start Progress on Release Ticket
       if: ${{ inputs.start-progress == 'true' }}
-      uses: SonarSource/release-github-actions/update-release-ticket-status@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+      uses: SonarSource/release-github-actions/update-release-ticket-status@6452648457a9c19d90b859faf36465af99454bc6
       with:
         ticket_key: ${{ steps.run_python_script.outputs.ticket_key }}
         status: "Start Progress"

--- a/create-jira-version/action.yml
+++ b/create-jira-version/action.yml
@@ -42,7 +42,7 @@ runs:
       shell: bash
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
-    - uses: SonarSource/release-github-actions/get-jira-version@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+    - uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
       if: ${{ !inputs.jira_version_name }}
 
     - name: Determine New Jira Version

--- a/get-jira-release-notes/action.yml
+++ b/get-jira-release-notes/action.yml
@@ -44,7 +44,7 @@ runs:
 
     - name: Get JIRA_VERSION if not provided
       if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION }}
-      uses: SonarSource/release-github-actions/get-jira-version@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+      uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
 
     - name: Get Jira release notes and URL
       id: get_notes

--- a/get-jira-version/action.yml
+++ b/get-jira-version/action.yml
@@ -10,7 +10,7 @@ outputs:
 runs:
     using: "composite"
     steps:
-      - uses: SonarSource/release-github-actions/get-release-version@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+      - uses: SonarSource/release-github-actions/get-release-version@6452648457a9c19d90b859faf36465af99454bc6
         if: ${{ !env.RELEASE_VERSION }}
       - name: Get jira version from release version
         id: get_version

--- a/release-jira-version/action.yml
+++ b/release-jira-version/action.yml
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
-    - uses: SonarSource/release-github-actions/get-jira-version@a45b0fc517482d2b8d524a674a7f8ce6cd8ddbdb
+    - uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
       if: ${{ !inputs.jira_version_name }}
 
     - name: Determine Jira Version


### PR DESCRIPTION
Needs a 2nd update of the refs for all actions that use get-jira-version (so that the new ref that includes the updated get-jira-version that references get-release-version can be used)