### PR TITLE
Update actions inputs & outputs

### DIFF
--- a/.github/workflows/test-all-on-master.yml
+++ b/.github/workflows/test-all-on-master.yml
@@ -1,0 +1,30 @@
+name: Test All Actions on Master
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  test-get-jira-version:
+    uses: ./.github/workflows/test-get-jira-version.yml
+
+  test-create-jira-version:
+    uses: ./.github/workflows/test-create-jira-version.yml
+
+  test-release-jira-version:
+    uses: ./.github/workflows/test-release-jira-version.yml
+
+  test-create-jira-release-ticket:
+    uses: ./.github/workflows/test-create-jira-release-ticket.yml
+
+  test-create-integration-ticket:
+    uses: ./.github/workflows/test-create-integration-ticket.yml
+
+  test-check-releasability-status:
+    uses: ./.github/workflows/test-check-releasability-status.yml
+
+  test-get-release-version:
+    uses: ./.github/workflows/test-get-release-version.yml
+
+  test-get-jira-release-notes:
+    uses: ./.github/workflows/test-get-jira-release-notes.yml

--- a/.github/workflows/test-check-releasability-status.yml
+++ b/.github/workflows/test-check-releasability-status.yml
@@ -1,6 +1,7 @@
 name: Test Check Releasability Status Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'check-releasability-status/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'check-releasability-status/**'
       - '.github/workflows/test-check-releasability-status.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-check-releasability-status.yml
+++ b/.github/workflows/test-check-releasability-status.yml
@@ -2,11 +2,22 @@ name: Test Check Releasability Status Action
 
 on:
   pull_request:
+    paths:
+      - 'check-releasability-status/**'
+      - '.github/workflows/test-check-releasability-status.yml'
   merge_group:
+    paths:
+      - 'check-releasability-status/**'
+      - '.github/workflows/test-check-releasability-status.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'check-releasability-status/**'
+      - '.github/workflows/test-check-releasability-status.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-check-releasability-status.yml
+++ b/.github/workflows/test-check-releasability-status.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'check-releasability-status/**'
       - '.github/workflows/test-check-releasability-status.yml'
-  merge_group:
-    paths:
-      - 'check-releasability-status/**'
-      - '.github/workflows/test-check-releasability-status.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-integration-ticket.yml
+++ b/.github/workflows/test-create-integration-ticket.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'create-integration-ticket/**'
       - '.github/workflows/test-create-integration-ticket.yml'
-  merge_group:
-    paths:
-      - 'create-integration-ticket/**'
-      - '.github/workflows/test-create-integration-ticket.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-integration-ticket.yml
+++ b/.github/workflows/test-create-integration-ticket.yml
@@ -1,6 +1,7 @@
 name: Test Create Integration Ticket Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'create-integration-ticket/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'create-integration-ticket/**'
       - '.github/workflows/test-create-integration-ticket.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-integration-ticket.yml
+++ b/.github/workflows/test-create-integration-ticket.yml
@@ -2,11 +2,22 @@ name: Test Create Integration Ticket Action
 
 on:
   pull_request:
+    paths:
+      - 'create-integration-ticket/**'
+      - '.github/workflows/test-create-integration-ticket.yml'
   merge_group:
+    paths:
+      - 'create-integration-ticket/**'
+      - '.github/workflows/test-create-integration-ticket.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'create-integration-ticket/**'
+      - '.github/workflows/test-create-integration-ticket.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-create-jira-release-ticket.yml
+++ b/.github/workflows/test-create-jira-release-ticket.yml
@@ -2,11 +2,22 @@ name: Test Create Jira Release Ticket Action
 
 on:
   pull_request:
+    paths:
+      - 'create-jira-release-ticket/**'
+      - '.github/workflows/test-create-jira-release-ticket.yml'
   merge_group:
+    paths:
+      - 'create-jira-release-ticket/**'
+      - '.github/workflows/test-create-jira-release-ticket.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'create-jira-release-ticket/**'
+      - '.github/workflows/test-create-jira-release-ticket.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-create-jira-release-ticket.yml
+++ b/.github/workflows/test-create-jira-release-ticket.yml
@@ -1,6 +1,7 @@
 name: Test Create Jira Release Ticket Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'create-jira-release-ticket/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'create-jira-release-ticket/**'
       - '.github/workflows/test-create-jira-release-ticket.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-jira-release-ticket.yml
+++ b/.github/workflows/test-create-jira-release-ticket.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'create-jira-release-ticket/**'
       - '.github/workflows/test-create-jira-release-ticket.yml'
-  merge_group:
-    paths:
-      - 'create-jira-release-ticket/**'
-      - '.github/workflows/test-create-jira-release-ticket.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-jira-version.yml
+++ b/.github/workflows/test-create-jira-version.yml
@@ -1,6 +1,7 @@
 name: Test Create Jira Version Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'create-jira-version/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'create-jira-version/**'
       - '.github/workflows/test-create-jira-version.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-jira-version.yml
+++ b/.github/workflows/test-create-jira-version.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'create-jira-version/**'
       - '.github/workflows/test-create-jira-version.yml'
-  merge_group:
-    paths:
-      - 'create-jira-version/**'
-      - '.github/workflows/test-create-jira-version.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-create-jira-version.yml
+++ b/.github/workflows/test-create-jira-version.yml
@@ -2,11 +2,22 @@ name: Test Create Jira Version Action
 
 on:
   pull_request:
+    paths:
+      - 'create-jira-version/**'
+      - '.github/workflows/test-create-jira-version.yml'
   merge_group:
+    paths:
+      - 'create-jira-version/**'
+      - '.github/workflows/test-create-jira-version.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'create-jira-version/**'
+      - '.github/workflows/test-create-jira-version.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-get-jira-release-notes.yml
+++ b/.github/workflows/test-get-jira-release-notes.yml
@@ -2,11 +2,22 @@ name: Test Get Jira Release Notes Action
 
 on:
   pull_request:
+    paths:
+      - 'get-jira-release-notes/**'
+      - '.github/workflows/test-get-jira-release-notes.yml'
   merge_group:
+    paths:
+      - 'get-jira-release-notes/**'
+      - '.github/workflows/test-get-jira-release-notes.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'get-jira-release-notes/**'
+      - '.github/workflows/test-get-jira-release-notes.yml'
   workflow_dispatch:
 
 jobs:
@@ -58,7 +69,7 @@ jobs:
         uses: ./get-jira-release-notes
         env:
           JIRA_PROJECT_KEY: 'TEST'
-          JIRA_VERSION: '1.0.0'
+          JIRA_VERSION_NAME: '1.0.0'
         # This should fail due to missing Jira credentials, but validation should pass
 
       - name: Test action with mixed inputs (input overrides env)
@@ -69,7 +80,7 @@ jobs:
           jira-project-key: 'OVERRIDE'  # This should override JIRA_PROJECT_KEY
         env:
           JIRA_PROJECT_KEY: 'TEST'
-          JIRA_VERSION: '1.0.0'
+          JIRA_VERSION_NAME: '1.0.0'
         # This should fail due to missing Jira credentials, but validation should pass
 
       - name: Test environment variable outputs (mock test)

--- a/.github/workflows/test-get-jira-release-notes.yml
+++ b/.github/workflows/test-get-jira-release-notes.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'get-jira-release-notes/**'
       - '.github/workflows/test-get-jira-release-notes.yml'
-  merge_group:
-    paths:
-      - 'get-jira-release-notes/**'
-      - '.github/workflows/test-get-jira-release-notes.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-jira-release-notes.yml
+++ b/.github/workflows/test-get-jira-release-notes.yml
@@ -1,6 +1,7 @@
 name: Test Get Jira Release Notes Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'get-jira-release-notes/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'get-jira-release-notes/**'
       - '.github/workflows/test-get-jira-release-notes.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-jira-version.yml
+++ b/.github/workflows/test-get-jira-version.yml
@@ -2,11 +2,22 @@ name: Test Get Jira Version Action
 
 on:
   pull_request:
+    paths:
+      - 'get-jira-version/**'
+      - '.github/workflows/test-get-jira-version.yml'
   merge_group:
+    paths:
+      - 'get-jira-version/**'
+      - '.github/workflows/test-get-jira-version.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'get-jira-version/**'
+      - '.github/workflows/test-get-jira-version.yml'
   workflow_dispatch:
 
 jobs:
@@ -23,8 +34,8 @@ jobs:
 
       - name: Verify standard version output
         run: |
-          echo "Expected: 1.2.3, Got: ${{ steps.test1.outputs.JIRA_VERSION }}"
-          if [ "${{ steps.test1.outputs.JIRA_VERSION }}" != "1.2.3" ]; then
+          echo "Expected: 1.2.3, Got: ${{ steps.test1.outputs.jira-version-name }}"
+          if [ "${{ steps.test1.outputs.jira-version-name }}" != "1.2.3" ]; then
             echo "❌ Test failed for standard version"
             exit 1
           fi
@@ -38,8 +49,8 @@ jobs:
 
       - name: Verify trailing zero removal
         run: |
-          echo "Expected: 2.1, Got: ${{ steps.test2.outputs.JIRA_VERSION }}"
-          if [ "${{ steps.test2.outputs.JIRA_VERSION }}" != "2.1" ]; then
+          echo "Expected: 2.1, Got: ${{ steps.test2.outputs.jira-version-name }}"
+          if [ "${{ steps.test2.outputs.jira-version-name }}" != "2.1" ]; then
             echo "❌ Test failed for trailing zero removal"
             exit 1
           fi
@@ -53,8 +64,8 @@ jobs:
 
       - name: Verify no trailing zero
         run: |
-          echo "Expected: 3.4.5, Got: ${{ steps.test3.outputs.JIRA_VERSION }}"
-          if [ "${{ steps.test3.outputs.JIRA_VERSION }}" != "3.4.5" ]; then
+          echo "Expected: 3.4.5, Got: ${{ steps.test3.outputs.jira-version-name }}"
+          if [ "${{ steps.test3.outputs.jira-version-name }}" != "3.4.5" ]; then
             echo "❌ Test failed for no trailing zero"
             exit 1
           fi
@@ -68,8 +79,8 @@ jobs:
 
       - name: Verify single digit version
         run: |
-          echo "Expected: 1.0, Got: ${{ steps.test4.outputs.JIRA_VERSION }}"
-          if [ "${{ steps.test4.outputs.JIRA_VERSION }}" != "1.0" ]; then
+          echo "Expected: 1.0, Got: ${{ steps.test4.outputs.jira-version-name }}"
+          if [ "${{ steps.test4.outputs.jira-version-name }}" != "1.0" ]; then
             echo "❌ Test failed for single digit version"
             exit 1
           fi
@@ -81,13 +92,13 @@ jobs:
         run: |
           # Run the action steps manually to test env var
           VERSION=$(echo "$RELEASE_VERSION" | cut -d '.' -f 1-3)
-          JIRA_VERSION=$(echo "$VERSION" | sed 's/\.0$//')
-          echo "JIRA_VERSION=${JIRA_VERSION}" >> "$GITHUB_ENV"
+          JIRA_VERSION_NAME=$(echo "$VERSION" | sed 's/\.0$//')
+          echo "JIRA_VERSION_NAME=${JIRA_VERSION_NAME}" >> "$GITHUB_ENV"
 
       - name: Verify environment variable
         run: |
-          echo "Environment JIRA_VERSION: $JIRA_VERSION"
-          if [ "$JIRA_VERSION" != "5.6.7" ]; then
+          echo "Environment JIRA_VERSION_NAME: $JIRA_VERSION_NAME"
+          if [ "$JIRA_VERSION_NAME" != "5.6.7" ]; then
             echo "❌ Environment variable test failed"
             exit 1
           fi
@@ -101,8 +112,8 @@ jobs:
 
       - name: Verify major version only
         run: |
-          echo "Expected: 1.0, Got: ${{ steps.test5.outputs.JIRA_VERSION }}"
-          if [ "${{ steps.test5.outputs.JIRA_VERSION }}" != "1.0" ]; then
+          echo "Expected: 1.0, Got: ${{ steps.test5.outputs.jira-version-name }}"
+          if [ "${{ steps.test5.outputs.jira-version-name }}" != "1.0" ]; then
             echo "❌ Test failed for major version only"
             exit 1
           fi

--- a/.github/workflows/test-get-jira-version.yml
+++ b/.github/workflows/test-get-jira-version.yml
@@ -1,6 +1,7 @@
 name: Test Get Jira Version Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'get-jira-version/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'get-jira-version/**'
       - '.github/workflows/test-get-jira-version.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-jira-version.yml
+++ b/.github/workflows/test-get-jira-version.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'get-jira-version/**'
       - '.github/workflows/test-get-jira-version.yml'
-  merge_group:
-    paths:
-      - 'get-jira-version/**'
-      - '.github/workflows/test-get-jira-version.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'get-release-version/**'
       - '.github/workflows/test-get-release-version.yml'
-  merge_group:
-    paths:
-      - 'get-release-version/**'
-      - '.github/workflows/test-get-release-version.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -1,6 +1,7 @@
 name: Test Get Release Version Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'get-release-version/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'get-release-version/**'
       - '.github/workflows/test-get-release-version.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-get-release-version.yml
+++ b/.github/workflows/test-get-release-version.yml
@@ -2,11 +2,22 @@ name: Test Get Release Version Action
 
 on:
   pull_request:
+    paths:
+      - 'get-release-version/**'
+      - '.github/workflows/test-get-release-version.yml'
   merge_group:
+    paths:
+      - 'get-release-version/**'
+      - '.github/workflows/test-get-release-version.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'get-release-version/**'
+      - '.github/workflows/test-get-release-version.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-release-jira-version.yml
+++ b/.github/workflows/test-release-jira-version.yml
@@ -2,11 +2,22 @@ name: Test Release Jira Version Action
 
 on:
   pull_request:
+    paths:
+      - 'release-jira-version/**'
+      - '.github/workflows/test-release-jira-version.yml'
   merge_group:
+    paths:
+      - 'release-jira-version/**'
+      - '.github/workflows/test-release-jira-version.yml'
   push:
     branches:
       - master
+  push:
+    branches:
       - branch-*
+    paths:
+      - 'release-jira-version/**'
+      - '.github/workflows/test-release-jira-version.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-release-jira-version.yml
+++ b/.github/workflows/test-release-jira-version.yml
@@ -6,10 +6,6 @@ on:
     paths:
       - 'release-jira-version/**'
       - '.github/workflows/test-release-jira-version.yml'
-  merge_group:
-    paths:
-      - 'release-jira-version/**'
-      - '.github/workflows/test-release-jira-version.yml'
   push:
     branches:
       - branch-*

--- a/.github/workflows/test-release-jira-version.yml
+++ b/.github/workflows/test-release-jira-version.yml
@@ -1,6 +1,7 @@
 name: Test Release Jira Version Action
 
 on:
+  workflow_call:
   pull_request:
     paths:
       - 'release-jira-version/**'
@@ -9,9 +10,6 @@ on:
     paths:
       - 'release-jira-version/**'
       - '.github/workflows/test-release-jira-version.yml'
-  push:
-    branches:
-      - master
   push:
     branches:
       - branch-*

--- a/create-integration-ticket/README.md
+++ b/create-integration-ticket/README.md
@@ -33,10 +33,10 @@ This action requires:
 
 ## Outputs
 
-| Output       | Description                               |
-|--------------|-------------------------------------------|
-| `ticket-key` | The key of the created Jira ticket       |
-| `ticket-url` | The URL of the created Jira ticket       |
+| Output       | Description                        |
+|--------------|------------------------------------|
+| `ticket-key` | The key of the created Jira ticket |
+| `ticket-url` | The URL of the created Jira ticket |
 
 ## Usage
 

--- a/create-integration-ticket/test_create_integration_ticket.py
+++ b/create-integration-ticket/test_create_integration_ticket.py
@@ -166,6 +166,7 @@ class TestCreateIntegrationTicket(unittest.TestCase):
         self.assertEqual(call_args['issuetype'], {'name': 'Task'})
         self.assertEqual(call_args['summary'], 'Integration ticket for release')
 
+    # noinspection DuplicatedCode
     def test_create_integration_ticket_with_improvement_type(self):
         """Test creating integration ticket with Improvement issue type when Task is not available."""
         mock_jira = Mock()
@@ -198,6 +199,7 @@ class TestCreateIntegrationTicket(unittest.TestCase):
         call_args = mock_jira.create_issue.call_args[1]['fields']
         self.assertEqual(call_args['issuetype'], {'name': 'Improvement'})
 
+    # noinspection DuplicatedCode
     def test_create_integration_ticket_with_first_available_type(self):
         """Test creating integration ticket with first available issue type."""
         mock_jira = Mock()
@@ -340,7 +342,7 @@ class TestCreateIntegrationTicket(unittest.TestCase):
     @patch('create_integration_ticket.link_tickets')
     @patch('sys.stderr', new_callable=StringIO)
     def test_main_successful_execution(self, mock_stderr, mock_link_tickets,
-                                     mock_create_ticket, mock_validate_release_ticket, mock_get_jira):
+                                       mock_create_ticket, mock_validate_release_ticket, mock_get_jira):
         """Test successful execution through main function."""
         # Mock JIRA instance
         mock_jira = Mock()
@@ -401,7 +403,7 @@ class TestCreateIntegrationTicket(unittest.TestCase):
     @patch('create_integration_ticket.link_tickets')
     @patch('sys.stderr', new_callable=StringIO)
     def test_main_with_minimal_parameters(self, mock_stderr, mock_link_tickets,
-                                        mock_create_ticket, mock_validate_ticket, mock_get_jira):
+                                          mock_create_ticket, mock_validate_ticket, mock_get_jira):
         """Test main function with minimal required parameters."""
         # Mock JIRA instance
         mock_jira = Mock()

--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -20,7 +20,6 @@ inputs:
     description: 'The version being released (e.g., 11.44.2), or leave empty to use the release version.'
   use-jira-sandbox:
     description: "Use the sandbox server instead of the production Jira."
-    default: 'false'
   documentation-status:
     description: 'Status of the documentation'
     default: 'N/A'

--- a/create-jira-release-ticket/create_release_ticket.py
+++ b/create-jira-release-ticket/create_release_ticket.py
@@ -22,6 +22,7 @@ CUSTOM_FIELDS = {
 }
 
 
+# noinspection DuplicatedCode
 def eprint(*args, **kwargs):
     """
     Prints messages to the standard error stream (stderr).
@@ -62,7 +63,6 @@ def get_jira_instance(jira_url):
     except Exception as e:
         eprint(f"An unexpected error occurred during JIRA connection: {e}")
         sys.exit(1)
-
 
 
 def create_release_ticket(jira_client, args, link_to_release_notes):

--- a/create-jira-release-ticket/test_create_release_ticket.py
+++ b/create-jira-release-ticket/test_create_release_ticket.py
@@ -81,7 +81,7 @@ class TestCreateReleaseTicket(unittest.TestCase):
 
         self.assertEqual(result, mock_ticket)
         mock_jira.create_issue.assert_called_once()
-        
+
         # Verify the issue creation call
         call_args = mock_jira.create_issue.call_args[1]['fields']
         self.assertEqual(call_args['project'], 'REL')
@@ -120,7 +120,7 @@ class TestCreateReleaseTicket(unittest.TestCase):
 
         self.assertEqual(result, mock_ticket)
         mock_jira.create_issue.assert_called_once()
-        
+
         # Verify the issue creation call - should not include targeted_product
         call_args = mock_jira.create_issue.call_args[1]['fields']
         self.assertNotIn('customfield_10163', call_args)  # TARGETED_PRODUCT should not be set
@@ -146,7 +146,7 @@ class TestCreateReleaseTicket(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as cm:
             create_release_ticket(mock_jira, args, 'https://release.url')
-        
+
         self.assertEqual(cm.exception.code, 1)
 
     @patch('sys.argv', [

--- a/create-jira-version/action.yml
+++ b/create-jira-version/action.yml
@@ -3,22 +3,21 @@ name: Create Jira Version
 description: 'Creates a Jira version.'
 
 inputs:
-    jira_project_key:
-        description: 'The key of the Jira project (e.g., SONARIAC).'
-        required: true
-    jira_version_name:
-        description: 'The name of the Jira version to create (e.g., 1.2.3).'
+    jira-project-key:
+        description: 'The key of the Jira project (e.g., SONARIAC). Required if JIRA_PROJECT_KEY env var is not set.'
         required: false
-    use_jira_sandbox:
-        description: "Use the sandbox Jira server instead of production."
+    jira-version-name:
+        description: 'The name of the Jira version to create (e.g., 1.2.3). Can also be set via JIRA_VERSION_NAME environment variable.'
         required: false
-        default: 'false'
+    use-jira-sandbox:
+        description: "Use the sandbox server instead of the production Jira. Can also be controlled via USE_JIRA_SANDBOX environment variable."
+        required: false
 
 outputs:
-    jira_version_id:
+    jira-version-id:
         description: 'The ID of the created Jira version.'
         value: ${{ steps.run_python_script.outputs.new_version_id }}
-    jira_version_name:
+    jira-version-name:
         description: 'The name of the created Jira version.'
         value: ${{ steps.run_python_script.outputs.new_version_name }}
 
@@ -43,14 +42,15 @@ runs:
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
     - uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
-      if: ${{ !inputs.jira_version_name }}
+      id: get-jira-version
+      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION_NAME }}
 
     - name: Determine New Jira Version
-      id: determine_version_name
-      if: ${{ !inputs.jira_version_name }}
+      id: determine-version-name
+      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION_NAME }}
       shell: bash
       run: |
-        echo "VERSION_NAME=$(echo "${{ steps.get-jira-version.outputs.jira_version }}" | awk -F. '{$NF+=1; OFS="."; print $0}')" >> $GITHUB_OUTPUT
+        echo "VERSION_NAME=$(echo "${{ steps.get-jira-version.outputs.jira-version-name }}" | awk -F. '{$NF+=1; OFS="."; print $0}')" >> $GITHUB_OUTPUT
 
     - name: Create Jira Version
       id: run_python_script
@@ -61,8 +61,15 @@ runs:
         JIRA_PROD_URL: "https://sonarsource.atlassian.net/"
         JIRA_SANDBOX_URL: "https://sonarsource-sandbox-608.atlassian.net/"
       run: |
-          python ${{ github.action_path }}/create_jira_version.py \
-          --project-key="${{ inputs.jira_project_key }}" \
-          --version-name="${{ inputs.jira_version_name || steps.determine_version_name.outputs.VERSION_NAME }}" \
-          --jira-url="${{ ((inputs.use_jira_sandbox || env.USE_JIRA_SANDBOX) == 'true') && env.JIRA_SANDBOX_URL || env.JIRA_PROD_URL }}" 
+        PROJECT_KEY="${{ inputs.jira-project-key || env.JIRA_PROJECT_KEY }}"
+        
+        if [[ -z "$PROJECT_KEY" ]]; then
+          echo "::error::Both jira-project-key input and JIRA_PROJECT_KEY environment variable are missing. One must be provided."
+          exit 1
+        fi
+
+        python ${{ github.action_path }}/create_jira_version.py \
+          --project-key="$PROJECT_KEY" \
+          --version-name="${{ inputs.jira-version-name || env.JIRA_VERSION_NAME }}" \
+          --jira-url="${{ ((inputs.use-jira-sandbox || env.USE_JIRA_SANDBOX) == 'true') && env.JIRA_SANDBOX_URL || env.JIRA_PROD_URL }}" 
           >> $GITHUB_OUTPUT

--- a/create-jira-version/create_jira_version.py
+++ b/create-jira-version/create_jira_version.py
@@ -11,9 +11,12 @@ import sys
 from jira import JIRA
 from jira.exceptions import JIRAError
 
+
+# noinspection DuplicatedCode
 def eprint(*args, **kwargs):
     """Prints messages to the standard error stream (stderr) for logging."""
     print(*args, file=sys.stderr, **kwargs)
+
 
 # noinspection DuplicatedCode
 def get_jira_instance(jira_url):
@@ -42,6 +45,7 @@ def get_jira_instance(jira_url):
     except Exception as e:
         eprint(f"An unexpected error occurred during JIRA connection: {e}")
         sys.exit(1)
+
 
 def main():
     """Main function to orchestrate the creation process."""
@@ -85,7 +89,6 @@ def main():
         else:
             eprint(f"Error: Failed to create new version. Status: {e.status_code}, Text: {e.text}")
             sys.exit(1)
-
 
 
 if __name__ == "__main__":

--- a/create-jira-version/test_create_jira_version.py
+++ b/create-jira-version/test_create_jira_version.py
@@ -34,6 +34,7 @@ class TestCreateJiraVersion(unittest.TestCase):
             get_jira_instance('https://test.jira.com')
         self.assertEqual(cm.exception.code, 1)
 
+    # noinspection DuplicatedCode
     @patch.dict(os.environ, {'JIRA_USER': 'test', 'JIRA_TOKEN': 'token'})
     @patch('create_jira_version.JIRA')
     def test_get_jira_instance_success(self, mock_jira_class):

--- a/get-jira-release-notes/README.md
+++ b/get-jira-release-notes/README.md
@@ -16,16 +16,16 @@ The action retrieves Jira release information by:
 
 This action depends on:
 - [SonarSource/vault-action-wrapper](https://github.com/SonarSource/vault-action-wrapper) for retrieving Jira credentials
-- [SonarSource/release-github-actions/get-jira-version](https://github.com/SonarSource/release-github-actions) when neither jira-version-name nor JIRA_VERSION are provided
+- [SonarSource/release-github-actions/get-jira-version](https://github.com/SonarSource/release-github-actions) when neither jira-version-name nor JIRA_VERSION_NAME are provided
 
 ## Inputs
 
-| Input               | Description                                                                                                                                                                                                                 | Required | Default                                                     |
-|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------|
-| `jira-project-key`  | The key of the Jira project (e.g., SONARIAC). Can also be set via `JIRA_PROJECT_KEY` environment variable                                                                                                                   | No*      | -                                                           |
-| `jira-version-name` | The name of the Jira version/fixVersion (e.g., 1.2.3). Can also be set via `JIRA_VERSION` environment variable. If neither is provided, the action will attempt to automatically fetch the version using `get-jira-version` | No       | -                                                           |
-| `use-jira-sandbox`  | Use the sandbox Jira server instead of production. Can also be controlled via `USE_JIRA_SANDBOX` environment variable                                                                                                       | No       | `false`                                                     |
-| `issue-types`       | Comma-separated list of issue types to include in the release notes, in order                                                                                                                                               | No       | `New Feature,False Positive,False Negative,Bug,Improvement` |
+| Input               | Description                                                                                                                                                                                                                      | Required | Default                                                     |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-------------------------------------------------------------|
+| `jira-project-key`  | The key of the Jira project (e.g., SONARIAC). Can also be set via `JIRA_PROJECT_KEY` environment variable                                                                                                                        | No*      | -                                                           |
+| `jira-version-name` | The name of the Jira version/fixVersion (e.g., 1.2.3). Can also be set via `JIRA_VERSION_NAME` environment variable. If neither is provided, the action will attempt to automatically fetch the version using `get-jira-version` | No       | -                                                           |
+| `use-jira-sandbox`  | Use the sandbox Jira server instead of production. Can also be controlled via `USE_JIRA_SANDBOX` environment variable                                                                                                            | No       | `false`                                                     |
+| `issue-types`       | Comma-separated list of issue types to include in the release notes, in order                                                                                                                                                    | No       | `New Feature,False Positive,False Negative,Bug,Improvement` |
 
 *Either the input or corresponding environment variable must be provided for jira-project-key.
 
@@ -81,7 +81,7 @@ This action depends on:
   uses: SonarSource/release-github-actions/get-jira-release-notes@master
   env:
     JIRA_PROJECT_KEY: 'SONARIAC'
-    JIRA_VERSION: '1.2.3'
+    JIRA_VERSION_NAME: '1.2.3'
 ```
 
 ### Mixed usage (inputs override environment variables)
@@ -93,7 +93,7 @@ This action depends on:
     jira-project-key: 'OVERRIDE_PROJECT'  # This overrides JIRA_PROJECT_KEY
   env:
     JIRA_PROJECT_KEY: 'SONARIAC'
-    JIRA_VERSION: '1.2.3'
+    JIRA_VERSION_NAME: '1.2.3'
 ```
 
 ### With automatic version fetching
@@ -144,7 +144,7 @@ The action uses a Python script that:
 
 - This action requires access to SonarSource's HashiCorp Vault for Jira credentials
 - Either `jira-project-key` input or `JIRA_PROJECT_KEY` environment variable must be provided
-- If neither `jira-version-name` input nor `JIRA_VERSION` environment variable is provided, the action will attempt to automatically fetch the version using the `get-jira-version` action
+- If neither `jira-version-name` input nor `JIRA_VERSION_NAME` environment variable is provided, the action will attempt to automatically fetch the version using the `get-jira-version` action
 - Inputs take priority over environment variables when both are set
 - The action will fail if the specified project or version doesn't exist in Jira
 - Issue types that don't match the specified categories will not appear in the release notes

--- a/get-jira-release-notes/action.yml
+++ b/get-jira-release-notes/action.yml
@@ -9,7 +9,6 @@ inputs:
     description: 'The name of the Jira version/fixVersion (e.g., 1.2.3). Can also be set via JIRA_VERSION_NAME environment variable.'
   use-jira-sandbox:
     description: "Use the sandbox Jira server instead of production."
-    default: 'false'
   issue-types:
     description: 'Optional comma-separated list of issue types to include, in order.'
     default: 'New Feature,False Positive,False Negative,Bug,Improvement'

--- a/get-jira-release-notes/action.yml
+++ b/get-jira-release-notes/action.yml
@@ -6,7 +6,7 @@ inputs:
   jira-project-key:
     description: 'The key of the Jira project (e.g., SONARIAC). Can also be set via JIRA_PROJECT_KEY environment variable.'
   jira-version-name:
-    description: 'The name of the Jira version/fixVersion (e.g., 1.2.3). Can also be set via JIRA_VERSION environment variable.'
+    description: 'The name of the Jira version/fixVersion (e.g., 1.2.3). Can also be set via JIRA_VERSION_NAME environment variable.'
   use-jira-sandbox:
     description: "Use the sandbox Jira server instead of production."
     default: 'false'
@@ -42,8 +42,8 @@ runs:
       shell: bash
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
-    - name: Get JIRA_VERSION if not provided
-      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION }}
+    - name: Get JIRA_VERSION_NAME if not provided
+      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION_NAME }}
       uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
 
     - name: Get Jira release notes and URL
@@ -56,7 +56,7 @@ runs:
         JIRA_SANDBOX_URL: "https://sonarsource-sandbox-608.atlassian.net/"
       run: |
         PROJECT_KEY="${{ inputs.jira-project-key || env.JIRA_PROJECT_KEY }}"
-        VERSION_NAME="${{ inputs.jira-version-name || env.JIRA_VERSION }}"
+        VERSION_NAME="${{ inputs.jira-version-name || env.JIRA_VERSION_NAME }}"
         
         if [[ -z "$PROJECT_KEY" || -z "$VERSION_NAME" ]]; then
           echo "::error::Both jira-project-key and jira-version-name must be provided"

--- a/get-jira-version/README.md
+++ b/get-jira-version/README.md
@@ -12,13 +12,17 @@ The action takes a release version (typically in the format `major.minor.patch.b
 
 This action depends on the [SonarSource/release-github-actions/get-release-version](https://github.com/SonarSource/release-github-actions) action to retrieve the release version.
 
-## Outputs/Environment Variables
+## Outputs
 
-| Output         | Description                                                 |
-|----------------|-------------------------------------------------------------|
-| `JIRA_VERSION` | The Jira-formatted version derived from the release version |
+| Output              | Description                                                 |
+|---------------------|-------------------------------------------------------------|
+| `jira-version-name` | The Jira-formatted version derived from the release version |
 
-This means you can reference the version in later steps using something like `${{ steps.jira-version.outputs.JIRA_VERSION }}` or `${{ env.JIRA_VERSION }}`.
+## Environment Variables
+
+| Variable             | Description                                                 |
+|----------------------|-------------------------------------------------------------|
+| `JIRA_VERSION_NAME`  | The Jira-formatted version derived from the release version |
 
 ## Usage
 
@@ -26,12 +30,12 @@ This means you can reference the version in later steps using something like `${
 - id: jira-version
   uses: SonarSource/release-github-actions/get-jira-version@master
   
-- run: echo "Jira version is ${{ steps.jira-version.outputs.JIRA_VERSION }}"
+- run: echo "Jira version is ${{ steps.jira-version.outputs.jira-version-name }}"
 
 # alternatively, you can access the version as an environment variable
 
 - uses: SonarSource/release-github-actions/get-jira-version@master
-- run: echo "Jira version is ${{ env.JIRA_VERSION }}"
+- run: echo "Jira version is ${{ env.JIRA_VERSION_NAME }}"
 
 ```
 
@@ -39,19 +43,19 @@ This means you can reference the version in later steps using something like `${
 
 If the release version is `1.2.3.45`, the action will:
 1. Extract `1.2.3` (first three components)
-2. Output `JIRA_VERSION=1.2.3`
+2. Output `jira-version-name=1.2.3` and set `JIRA_VERSION_NAME=1.2.3`
 
 If the release version is `2.1.0.12`, the action will:
 1. Extract `2.1.0` (first three components)
 2. Remove trailing `.0` to get `2.1`
-3. Output `JIRA_VERSION=2.1`
+3. Output `jira-version-name=2.1` and set `JIRA_VERSION_NAME=2.1`
 
 ## Implementation Details
 
 The action uses a bash script that:
 - Uses `cut` to extract the major.minor.patch components from the release version
 - Uses `sed` to remove trailing `.0` if present
-- Sets both the GitHub output and environment variable for the Jira version
+- Sets both the GitHub output (`jira-version-name`) and environment variable (`JIRA_VERSION_NAME`) for the Jira version
 
 ## Notes
 

--- a/get-jira-version/action.yml
+++ b/get-jira-version/action.yml
@@ -3,9 +3,9 @@ name: Get Jira Version
 description: Get jira version from the release version.
 
 outputs:
-  JIRA_VERSION:
+  jira-version-name:
     description: 'The Jira version derived from the release version.'
-    value: ${{ steps.get_version.outputs.JIRA_VERSION }}
+    value: ${{ steps.get_version.outputs.jira-version-name }}
 
 runs:
     using: "composite"
@@ -20,8 +20,8 @@ runs:
           VERSION=$(echo "$RELEASE_VERSION" | cut -d '.' -f 1-3)
           
           # Remove trailing '.0' if it exists (to match Jira version format)
-          JIRA_VERSION=$(echo "$VERSION" | sed 's/\.0$//')
+          JIRA_VERSION_NAME=$(echo "$VERSION" | sed 's/\.0$//')
 
-          echo "JIRA_VERSION: ${JIRA_VERSION}"
-          echo "JIRA_VERSION=${JIRA_VERSION}" >> "$GITHUB_ENV"
-          echo "JIRA_VERSION=${JIRA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "JIRA_VERSION_NAME: ${JIRA_VERSION_NAME}"
+          echo "JIRA_VERSION_NAME=${JIRA_VERSION_NAME}" >> "$GITHUB_ENV"
+          echo "jira-version-name=${JIRA_VERSION_NAME}" >> "$GITHUB_OUTPUT"

--- a/release-jira-version/README.md
+++ b/release-jira-version/README.md
@@ -6,8 +6,9 @@ This GitHub Action automates releasing a version in Jira.
 
 The action performs the following operations:
 1. Connecting to Jira using authentication credentials from Vault
-2. Finding a Jira version matching the `jira_version_name` input within the specified `jira_project_key`
-3. Marking that version as "released" in Jira, setting the release date to the current day
+2. Validating required project key from inputs or environment variables
+3. Finding a Jira version matching the `jira-version-name` input within the specified `jira-project-key`
+4. Marking that version as "released" in Jira, setting the release date to the current day
 
 ## Dependencies
 
@@ -17,11 +18,13 @@ This action depends on:
 
 ## Inputs
 
-| Input               | Description                                                                                                                                      | Required | Default         |
-|---------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
-| `jira_project_key`  | The key of the Jira project (e.g., SONARIAC)                                                                                                     | Yes      | -               |
-| `jira_version_name` | The name of the Jira version to release (e.g., 1.2.3). If not provided, the script will determine the next version based on the release version. | No       | Auto-determined |
-| `use_jira_sandbox`  | Use the sandbox Jira server instead of production. Can also be controlled via `USE_JIRA_SANDBOX` environment variable.                           | No       | `false`         |
+| Input               | Description                                                                                                                                                                  | Required | Default         |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
+| `jira-project-key`  | The key of the Jira project (e.g., SONARIAC). Can also be set via `JIRA_PROJECT_KEY` environment variable                                                                     | No*      | -               |
+| `jira-version-name` | The name of the Jira version to release (e.g., 1.2.3). Can also be set via `JIRA_VERSION_NAME` environment variable. If not provided, the script will determine the next version based on the release version. | No       | Auto-determined |
+| `use-jira-sandbox`  | Use the sandbox server instead of the production Jira. Can also be controlled via `USE_JIRA_SANDBOX` environment variable                                                     | No       | -               |
+
+*Either the input or corresponding environment variable must be provided for jira-project-key.
 
 ## Outputs
 
@@ -35,8 +38,8 @@ No outputs are defined for this action, as it primarily performs operations with
 - name: Release Jira Version
   uses: SonarSource/release-github-actions/release-jira-version@master
   with:
-    jira_project_key: 'SONARIAC'
-    jira_version_name: '1.2.3'
+    jira-project-key: 'SONARIAC'
+    jira-version-name: '1.2.3'
 ```
 
 ### Auto-determine version to release
@@ -45,38 +48,37 @@ No outputs are defined for this action, as it primarily performs operations with
 - name: Release Current Jira Version
   uses: SonarSource/release-github-actions/release-jira-version@master
   with:
-    jira_project_key: 'SONARIAC'
-    # jira_version_name is omitted - will auto-determine from the release version
+    jira-project-key: 'SONARIAC'
+    # jira-version-name is omitted - will auto-determine from the release version
 ```
 
-### Using sandbox environment (with input)
+### Using environment variables
 
 ```yaml
-- name: Release Jira Version in Sandbox
-  uses: SonarSource/release-github-actions/release-jira-version@master
-  with:
-    jira_project_key: 'SONARIAC'
-    jira_version_name: '1.2.3'
-    use_jira_sandbox: 'true'
-```
-
-### Using sandbox environment (with environment variable)
-
-```yaml
-- name: Release Jira Version in Sandbox
+- name: Release Jira Version
   uses: SonarSource/release-github-actions/release-jira-version@master
   env:
-    USE_JIRA_SANDBOX: 'true'
+    JIRA_PROJECT_KEY: 'SONARIAC'
+    JIRA_VERSION_NAME: '1.2.3'
+```
+
+### Using sandbox environment
+
+```yaml
+- name: Release Jira Version in Sandbox
+  uses: SonarSource/release-github-actions/release-jira-version@master
   with:
-    jira_project_key: 'SONARIAC'
-    jira_version_name: '1.2.3'
+    jira-project-key: 'SONARIAC'
+    jira-version-name: '1.2.3'
+    use-jira-sandbox: 'true'
 ```
 
 ## Implementation Details
 
 The action uses a Python script that:
 - Authenticates with Jira using credentials from HashiCorp Vault
-- Supports both production and sandbox Jira environments (via input or environment variable)
+- Validates required project key from inputs or environment variables
+- Supports both production and sandbox Jira environments via URL selection
 - Can auto-determine which version to release by finding the latest unreleased version
 - Releases the specified version using the Jira REST API
 
@@ -90,7 +92,8 @@ The [Jira API user](https://sonarsource.atlassian.net/jira/people/712020:9dcffe4
 ## Notes
 
 - This action requires access to SonarSource's HashiCorp Vault for Jira credentials
+- Either `jira-project-key` input or `JIRA_PROJECT_KEY` environment variable must be provided
+- Input parameters take precedence over environment variables when both are provided
 - The action supports both production and sandbox Jira environments
-- Environment variables take precedence when both input and environment variable are provided
 - Version names should follow semantic versioning patterns for best results
 - The released version will be marked with the current date as the release date

--- a/release-jira-version/action.yml
+++ b/release-jira-version/action.yml
@@ -3,18 +3,15 @@ description: 'Releases a specified Jira version and creates a new one.'
 author: 'SonarSource'
 
 inputs:
-  jira_project_key:
-    description: 'The key of the Jira project (e.g., SONARIAC).'
-    required: true
-  jira_version_name:
-    description: |
-      The name of the Jira version to release (e.g., 1.2.3).
-      If not provided, the script will determine the next version based on the Jira version.'
+  jira-project-key:
+    description: 'The key of the Jira project (e.g., SONARIAC). Required if JIRA_PROJECT_KEY env var is not set.'
     required: false
-  use_jira_sandbox:
-    description: "Use the sandbox Jira server instead of production."
+  jira-version-name:
+    description: 'The name of the Jira version to release (e.g., 1.2.3). Can also be set via JIRA_VERSION_NAME environment variable. If not provided, the script will determine the next version based on the Jira version.'
     required: false
-    default: 'false'
+  use-jira-sandbox:
+    description: "Use the sandbox server instead of the production Jira. Can also be controlled via USE_JIRA_SANDBOX environment variable."
+    required: false
 
 runs:
   using: "composite"
@@ -37,14 +34,15 @@ runs:
       run: pip install -r ${{ github.action_path }}/requirements.txt
 
     - uses: SonarSource/release-github-actions/get-jira-version@6452648457a9c19d90b859faf36465af99454bc6
-      if: ${{ !inputs.jira_version_name }}
+      id: get-jira-version
+      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION_NAME }}
 
     - name: Determine Jira Version
-      id: determine_version_name
-      if: ${{ !inputs.jira_version_name }}
+      id: determine-version-name
+      if: ${{ !inputs.jira-version-name && !env.JIRA_VERSION_NAME }}
       shell: bash
       run: |
-        echo "VERSION_NAME=$(echo "${{ steps.get-jira-version.outputs.jira_version }}" | awk -F. '{$NF+=1; OFS="."; print $0}')" >> $GITHUB_OUTPUT
+        echo "VERSION_NAME=$(echo "${{ steps.get-jira-version.outputs.jira-version-name }}" | awk -F. '{$NF+=1; OFS="."; print $0}')" >> $GITHUB_OUTPUT
 
     - name: Release Jira Version
       id: run_python_script
@@ -55,8 +53,15 @@ runs:
         JIRA_PROD_URL: "https://sonarsource.atlassian.net/"
         JIRA_SANDBOX_URL: "https://sonarsource-sandbox-608.atlassian.net/"
       run: |
+        PROJECT_KEY="${{ inputs.jira-project-key || env.JIRA_PROJECT_KEY }}"
+        
+        if [[ -z "$PROJECT_KEY" ]]; then
+          echo "::error::Both jira-project-key input and JIRA_PROJECT_KEY environment variable are missing. One must be provided."
+          exit 1
+        fi
+
         python ${{ github.action_path }}/release_jira_version.py \
-        --project-key="${{ inputs.jira_project_key }}" \
-        --version-name="${{ inputs.jira_version_name || steps.determine_version_name.outputs.VERSION_NAME }}" \
-        --jira-url="${{ ((inputs.use_jira_sandbox || env.USE_JIRA_SANDBOX) == 'true') && env.JIRA_SANDBOX_URL || env.JIRA_PROD_URL }}" \
+        --project-key="$PROJECT_KEY" \
+        --version-name="${{ inputs.jira-version-name || env.JIRA_VERSION_NAME || steps.determine-version-name.outputs.VERSION_NAME }}" \
+        --jira-url="${{ ((inputs.use-jira-sandbox || env.USE_JIRA_SANDBOX) == 'true') && env.JIRA_SANDBOX_URL || env.JIRA_PROD_URL }}" \
         >> $GITHUB_OUTPUT


### PR DESCRIPTION
The PR standardizes input and output naming conventions across all GitHub actions to use kebab-case
  format and improves environment variable handling:

  - Input/Output Naming: Converts all action inputs and outputs from snake_case/mixed formats
  to consistent kebab-case (e.g., jira_project_key → jira-project-key, JIRA_VERSION →
  jira-version-name)
  - Environment Variables: Updates environment variable names for consistency (JIRA_VERSION →
  JIRA_VERSION_NAME) and improves fallback logic
  - Default Value Cleanup: Removes hardcoded default values from action definitions where
  environment variables provide the defaults
  - Documentation: Updates README files and test workflows to reflect the new naming
  conventions

  This improves the consistency and maintainability of the action interfaces.
  
The PR also introduces a centralized test-all-on-master.yml workflow
  that runs all action tests on master branch pushes, while individual test workflows now use
  path-based filtering to trigger only relevant tests during PR and branch development. An
  alternative approach would be to apply the same path-based filtering to master branch merges
  instead of running all tests.