### PR TITLE
GHA-267 Move Jira version derivation to check-releasability

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -218,12 +218,17 @@ jobs:
       statuses: read
     outputs:
       release-version: ${{ steps.get-version.outputs.release-version }}
+      jira-version-name: ${{ steps.get-jira-version.outputs.jira-version-name }}
     steps:
       - name: Get Release Version
         id: get-version
         uses: SonarSource/release-github-actions/get-release-version@v1
         with:
           branch: ${{ inputs.branch }}
+
+      - name: Get Jira Version
+        id: get-jira-version
+        uses: SonarSource/release-github-actions/get-jira-version@v1
 
       - uses: SonarSource/gh-action_releasability@v3
         id: releasability
@@ -341,7 +346,7 @@ jobs:
       id-token: write
     outputs:
       release-version: ${{ needs.check-releasability.outputs.release-version || steps.get-release-version.outputs.release-version }}
-      jira-version-name: ${{ steps.get-jira-version.outputs.jira-version-name }}
+      jira-version-name: ${{ needs.check-releasability.outputs.jira-version-name || steps.get-jira-version.outputs.jira-version-name }}
       release-notes: ${{ inputs.release-notes != '' && inputs.release-notes || steps.get-jira-release-notes.outputs.release-notes }}
       jira-release-notes: ${{ inputs.release-notes != '' && inputs.release-notes || steps.get-jira-release-notes.outputs.jira-release-notes }}
       jira-release-url: ${{ steps.get-jira-release-notes.outputs.jira-release-url }}
@@ -356,6 +361,7 @@ jobs:
 
       - name: Get Jira Version
         id: get-jira-version
+        if: ${{ needs.check-releasability.result == 'skipped' }}
         uses: SonarSource/release-github-actions/get-jira-version@v1
 
       - name: Get Jira Release Notes


### PR DESCRIPTION
## Summary

- Moves the `get-jira-version` step from `prepare-release` into `check-releasability`, so an invalid Jira version (wrong format, already released, missing) fails fast — before any downstream work like creating release tickets or publishing GitHub releases.
- `prepare-release` falls back to running `get-jira-version` itself when `check-releasability` is skipped (`check-releasability: false`), preserving backwards compatibility.
- All downstream jobs continue consuming `needs.prepare-release.outputs.jira-version-name` unchanged.

## Test plan

- [ ] Verify `check-releasability` job outputs `jira-version-name` alongside `release-version`
- [ ] Verify `prepare-release` `jira-version-name` output uses `||` fallback: `needs.check-releasability.outputs.jira-version-name || steps.get-jira-version.outputs.jira-version-name`
- [ ] Verify `Get Jira Version` step in `prepare-release` has `if: needs.check-releasability.result == 'skipped'`
- [ ] No downstream job changes needed — they all read from `needs.prepare-release.outputs.jira-version-name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)