### PR TITLE
SONARJAVA-6276 Use mise action to install Maven if needed

### DIFF
--- a/bump-version/README.md
+++ b/bump-version/README.md
@@ -35,6 +35,6 @@ This action updates the version in Maven and Gradle files across your repository
 ```
 
 ## How it works
-- If `tool` is set to `maven`, runs `mvn versions:set` to update the version.
+- If `tool` is set to `maven`, runs `mvn versions:set` to update the version. The calling repository must provide a `mise.toml` that specifies `maven` and a JDK — these are installed via `mise-action` before `mvn versions:set` runs.
 - Otherwise, updates all `pom.xml` and `gradle.properties` files to the new version, skipping modules listed in `excluded-modules`.
 - Commits changes and creates a pull request.

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -26,6 +26,11 @@ runs:
   steps:
   - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+  - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+    if: ${{ inputs.tool == 'maven' }}
+    with:
+      version: 2026.3.13
+
   - name: Bump version
     shell: bash
     env:

--- a/bump-version/action.yml
+++ b/bump-version/action.yml
@@ -26,6 +26,15 @@ runs:
   steps:
   - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
+  - name: Check mise.toml exists
+    if: ${{ inputs.tool == 'maven' }}
+    shell: bash
+    run: |
+      if [[ ! -f mise.toml ]]; then
+        echo "ERROR: mise.toml not found — required when tool=maven"
+        exit 1
+      fi
+
   - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
     if: ${{ inputs.tool == 'maven' }}
     with:


### PR DESCRIPTION
Tested on a modified workflow in sonar-java:
* (master) https://github.com/SonarSource/sonar-java/actions/runs/24840114676/job/72711331533#step:3:106  fails due to missing mvn
* (tt/bump-version-mise) https://github.com/SonarSource/sonar-java/actions/runs/24840302500/job/72712023205 - mvn runs 