### PR TITLE
GHA-280 Accept Slack Channel IDs (not add "#" in front of them).

### DIFF
--- a/notify-slack/README.md
+++ b/notify-slack/README.md
@@ -13,14 +13,14 @@ This action depends on:
 
 ## Inputs
 
-| Input           | Description                                                                                            | Required | Default   |
-|-----------------|--------------------------------------------------------------------------------------------------------|----------|-----------|
-| `project-name`  | The display name of the project; used in the Slack username.                                           | Yes      | -         |
-| `icon`          | Emoji icon for the Slack message (Slack emoji code).                                                   | No       | `:alert:` |
-| `slack-channel` | Slack channel (without `#`) to post the notification into.                                             | Yes      | -         |
-| `message`       | The Slack message to send (mrkdwn format). Required when not using the deprecated `jobs` input.        | No       | -         |
-| `color`         | Slack attachment color (`good`, `danger`, `warning`, or a hex code).                                   | No       | `danger`  |
-| `jobs`          | **Deprecated.** A GitHub needs-like object of jobs and results. When `message` is not set, a failed-jobs summary is built from this input. Build the message in the caller and pass it via `message` instead. | No | - |
+| Input           | Description                                                                                                                                                                                                   | Required | Default   |
+|-----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|-----------|
+| `project-name`  | The display name of the project; used in the Slack username.                                                                                                                                                  | Yes      | -         |
+| `icon`          | Emoji icon for the Slack message (Slack emoji code).                                                                                                                                                          | No       | `:alert:` |
+| `slack-channel` | Slack channel name (without `#`) or channel ID (e.g. `C1234ABCDE`) to post the notification into.                                                                                                             | Yes      | -         |
+| `message`       | The Slack message to send (mrkdwn format). Required when not using the deprecated `jobs` input.                                                                                                               | No       | -         |
+| `color`         | Slack attachment color (`good`, `danger`, `warning`, or a hex code).                                                                                                                                          | No       | `danger`  |
+| `jobs`          | **Deprecated.** A GitHub needs-like object of jobs and results. When `message` is not set, a failed-jobs summary is built from this input. Build the message in the caller and pass it via `message` instead. | No       | -         |
 
 ## Outputs
 
@@ -98,5 +98,5 @@ The action is a composite action that:
 ## Notes
 
 - For failure notifications, use `if: failure()` on the step or job; otherwise it will also fire on success.
-- Do not prefix the channel with `#`.
+- Do not prefix the channel with `#`. Channel IDs (`C…`, `D…`, `G…`) are passed through as-is.
 - Message formatting uses mrkdwn (Slack's markdown dialect).

--- a/notify-slack/notify_slack.py
+++ b/notify-slack/notify_slack.py
@@ -7,6 +7,7 @@ Sends a Slack notification with a custom message or a list of failed jobs.
 
 import argparse
 import os
+import re
 import sys
 
 import requests
@@ -24,8 +25,13 @@ def require_env_token(name):
     return token
 
 
+_CHANNEL_ID_RE = re.compile(r'^[CDG][A-Z0-9]{8,10}$')
+
+
 def normalize_channel(channel):
-    """Ensures channel name starts with '#'."""
+    """Ensures channel name starts with '#', but leaves channel IDs (e.g. C1234ABCDE) unchanged."""
+    if _CHANNEL_ID_RE.match(channel):
+        return channel
     if not channel.startswith('#'):
         return f'#{channel}'
     return channel

--- a/notify-slack/test_notify_slack.py
+++ b/notify-slack/test_notify_slack.py
@@ -23,6 +23,17 @@ class TestNormalizeChannel(unittest.TestCase):
     def test_keeps_existing_hash(self):
         self.assertEqual(normalize_channel('#releases'), '#releases')
 
+    def test_channel_id_not_prefixed(self):
+        # C = public/private channel, D = DM, G = group DM
+        # 8 suffix chars (minimum)
+        self.assertEqual(normalize_channel('C1234ABCD'), 'C1234ABCD')
+        # 9 suffix chars (middle)
+        self.assertEqual(normalize_channel('C1234ABCDE'), 'C1234ABCDE')
+        self.assertEqual(normalize_channel('D0AB12XYZ9'), 'D0AB12XYZ9')
+        self.assertEqual(normalize_channel('G9Z8Y7X6W5'), 'G9Z8Y7X6W5')
+        # 10 suffix chars (maximum)
+        self.assertEqual(normalize_channel('C1234ABCDEF'), 'C1234ABCDEF')
+
 
 class TestSendSlackNotification(unittest.TestCase):
 


### PR DESCRIPTION
Add a regexp validation for Slack channel id format to avoid adding `#` in front of them. It wouldn't break existing logic with the exception of an edge case when someone explicitly names a channel something like "C1234ABCD" AND passes it without `#`, which is not very likely based on company convention.