### PR TITLE
GHA-283 Make `new-version` optional by default

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -64,7 +64,7 @@ on:
         type: string
       new-version:
         description: "New version to release"
-        required: true
+        required: false
         type: string
       create-slvs-ticket:
         description: "Create SLVS integration ticket"


### PR DESCRIPTION

Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Maintenance ticket in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Maintenance ticket in Jira without a parent 
-->
