### PR TITLE
GHA-315 Make KTLO epic project key and pattern configurable in automated-release workflow

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -7,6 +7,14 @@ on:
         description: "Jira project key"
         required: true
         type: string
+      ktlo-jira-project-key:
+        description: "Jira project key where the KTLO epic lives. Defaults to jira-project-key if not provided."
+        required: false
+        type: string
+      ktlo-epic-name-pattern:
+        description: "Regex pattern to match the KTLO epic summary. Defaults to 'KTLO'."
+        required: false
+        type: string
       project-name:
         description: "Project name"
         required: true
@@ -692,7 +700,8 @@ jobs:
         id: resolve-ktlo-epic
         uses: SonarSource/release-github-actions/resolve-ktlo-epic@v1
         with:
-          jira-project: ${{ inputs.jira-project-key }}
+          jira-project: ${{ inputs.ktlo-jira-project-key || inputs.jira-project-key }}
+          epic-name-pattern: ${{ inputs.ktlo-epic-name-pattern || 'KTLO' }}
           use-jira-sandbox: ${{ inputs.use-jira-sandbox }}
 
       - name: Create SQC Ticket

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -62,6 +62,8 @@ This workflow composes several actions from this repository:
 | `sq-cli-short-description`   | Short summary of SQ CLI related changes                                                                         | No       | -            |
 | `sqs-integration`            | Create SQS integration ticket and PR                                                                            | No       | `true`       |
 | `sqc-integration`            | Create SQC integration ticket and PR                                                                            | No       | `true`       |
+| `ktlo-jira-project-key`      | Jira project key where the KTLO epic lives. Defaults to `jira-project-key` if not provided.                    | No       | -            |
+| `ktlo-epic-name-pattern`     | Regex pattern to match the KTLO epic summary                                                                    | No       | `KTLO`       |
 | `runner-environment`         | Runner labels/environment                                                                                       | No       | `sonar-m`    |
 | `release-process`            | Release process documentation URL                                                                               | No       | General page |
 | `verbose`                    | When `true`, posts per-job summaries and a final run summary                                                    | No       | `false`      |


### PR DESCRIPTION
## Summary

- Adds `ktlo-jira-project-key` input to specify the Jira project where the KTLO epic lives (falls back to `jira-project-key` if not set)
- Adds `ktlo-epic-name-pattern` input to override the regex used to match the KTLO epic summary (defaults to `KTLO`)
- Updates `docs/AUTOMATED_RELEASE.md` with both new inputs

Both inputs are optional — existing callers require no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)