### PR TITLE
GHA-340 Add Analysis as a Service release PR update

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -31,6 +31,19 @@ on:
         description: "SQC Plugin artifacts"
         required: false
         type: string
+      plugin-artifacts-sqaa:
+        description: "SQAA Plugin artifacts"
+        required: false
+        type: string
+      sqaa-base-branch:
+        description: "Base branch for the SQAA pull request"
+        required: false
+        type: string
+        default: "master"
+      sqaa-reviewers:
+        description: "Comma-separated list of GitHub usernames to request a review on the SQAA pull request"
+        required: false
+        type: string
       use-jira-sandbox:
         description: "Use Jira sandbox"
         required: false
@@ -46,7 +59,7 @@ on:
         required: true
         type: string
       release-automation-secret-name:
-        description: "Release automation secret name to create integration PRs in SQS and SQC. If not provided uses `sonar-{plugin-name}-release-automation` as default."
+        description: "Release automation secret name to create integration PRs in SQS, SQC, and SQAA. If not provided uses `sonar-{plugin-name}-release-automation` as default."
         required: false
         type: string
       short-description:
@@ -113,6 +126,11 @@ on:
         required: false
         type: boolean
         default: true
+      sqaa-integration:
+        description: "Create SQAA PR in sonar-analysis-as-a-service"
+        required: false
+        type: boolean
+        default: false
       sqc-plugins-deployer-integration:
         description: "Also create a PR in sonar-plugins-deployer when sqc-integration is true. Disabled by default during the transition period."
         required: false
@@ -219,6 +237,9 @@ on:
       plugins-deployer-pull-request-url:
         description: "URL of the plugins-deployer pull request"
         value: ${{ jobs.update-analyzers.outputs.plugins-deployer-pull-request-url }}
+      sqaa-pull-request-url:
+        description: "URL of the SQAA analyzer-update pull request"
+        value: ${{ jobs.update-analysis-as-a-service.outputs.pull-request-url }}
       bump-version-pull-request-url:
         description: "URL of the version-bump pull request"
         value: ${{ jobs.bump-version.outputs.pull-request-url }}
@@ -866,6 +887,50 @@ jobs:
           if [ "$SQC_INTEGRATION" = "true" ]; then echo "- SQC PR: ${{ steps.update-sqc.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
           if [ "$SQC_INTEGRATION" = "true" ] && [ "$SQC_PLUGINS_DEPLOYER_INTEGRATION" = "true" ]; then echo "- Plugins Deployer PR: ${{ steps.update-plugins-deployer.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
 
+  # This step updates analyzer versions in Analysis as a Service by creating a pull request.
+  update-analysis-as-a-service:
+    name: Update Analyzer in Analysis as a Service
+    runs-on: ${{ inputs.runner-environment }}
+    needs: [ prepare-release ]
+    if: |
+      inputs.sqaa-integration &&
+      !cancelled() &&
+      needs.prepare-release.result == 'success'
+    permissions:
+      id-token: write
+    outputs:
+      pull-request-url: ${{ steps.update-sqaa.outputs.pull-request-url }}
+    steps:
+      - name: Update analyzer in Analysis as a Service
+        id: update-sqaa
+        uses: SonarSource/release-github-actions/update-analysis-as-a-service@v1
+        with:
+          release-version: ${{ needs.prepare-release.outputs.release-version }}
+          plugin-name: ${{ inputs.plugin-name }}
+          secret-name: ${{ inputs.release-automation-secret-name || format('sonar-{0}-release-automation', inputs.plugin-name) }}
+          plugin-artifacts: ${{ inputs.plugin-artifacts-sqaa }}
+          base-branch: ${{ inputs.sqaa-base-branch }}
+          draft: ${{ inputs.is-draft-release }}
+          reviewers: ${{ inputs.sqaa-reviewers }}
+
+      - name: Summary
+        if: ${{ inputs.verbose }}
+        shell: bash
+        env:
+          PLUGIN_NAME: ${{ inputs.plugin-name }}
+          PLUGIN_ARTIFACTS_SQAA: ${{ inputs.plugin-artifacts-sqaa }}
+          IS_DRAFT_RELEASE: ${{ inputs.is-draft-release == true && 'true' || 'false' }}
+        run: |
+          echo "## 🔄 Update Analysis as a Service" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### What happened" >> $GITHUB_STEP_SUMMARY
+          echo "- Prepared analyzer updates in \`sonar-analysis-as-a-service\` and opened a PR." >> $GITHUB_STEP_SUMMARY
+          echo "- Artifacts SQAA: \`$([ -n "$PLUGIN_ARTIFACTS_SQAA" ] && echo "$PLUGIN_ARTIFACTS_SQAA" || echo "$PLUGIN_NAME" )\`." >> $GITHUB_STEP_SUMMARY
+          echo "- Draft PR: \`$IS_DRAFT_RELEASE\`." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Results" >> $GITHUB_STEP_SUMMARY
+          echo "- SQAA PR: ${{ steps.update-sqaa.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+
   # This step summarizes the results of the entire release process.
   # It checks the outcomes of all previous steps and generates a summary indicating whether the release was
   # successful or failed, along with relevant links and information.
@@ -885,6 +950,7 @@ jobs:
       - bump-version
       - create-integration-tickets
       - update-analyzers
+      - update-analysis-as-a-service
     env:
         RELEASE_PROCESS: ${{ inputs.release-process }}
     steps:
@@ -904,6 +970,7 @@ jobs:
           SQS_PR_URL: ${{ needs.update-analyzers.outputs.sqs-pull-request-url || 'not created' }}
           SQC_PR_URL: ${{ needs.update-analyzers.outputs.sqc-pull-request-url || 'not created' }}
           PLUGINS_DEPLOYER_PR_URL: ${{ inputs.sqc-plugins-deployer-integration == true && needs.update-analyzers.outputs.plugins-deployer-pull-request-url || 'not created' }}
+          SQAA_PR_URL: ${{ inputs.sqaa-integration == true && needs.update-analysis-as-a-service.outputs.pull-request-url || 'not created' }}
           BUMP_VERSION_PR_URL: ${{ needs.bump-version.outputs.pull-request-url || 'not created' }}
           RESULT_CHECK_RELEASABILITY: ${{ needs.check-releasability.result }}
           RESULT_UPDATE_RULE_METADATA: ${{ needs.update-rule-metadata.result }}
@@ -914,9 +981,10 @@ jobs:
           RESULT_BUMP_VERSION: ${{ needs.bump-version.result }}
           RESULT_CREATE_INTEGRATION_TICKETS: ${{ needs.create-integration-tickets.result }}
           RESULT_UPDATE_ANALYZERS: ${{ needs.update-analyzers.result }}
+          RESULT_UPDATE_ANALYSIS_AS_A_SERVICE: ${{ needs.update-analysis-as-a-service.result }}
         run: |
           ALL_SUCCESS=true
-          for result in "$RESULT_CHECK_RELEASABILITY" "$RESULT_UPDATE_RULE_METADATA" "$RESULT_PREPARE_RELEASE" "$RESULT_PUBLISH_GITHUB_RELEASE" "$RESULT_CREATE_RELEASE_TICKET" "$RESULT_RELEASE_IN_JIRA" "$RESULT_CREATE_INTEGRATION_TICKETS" "$RESULT_UPDATE_ANALYZERS" "$RESULT_BUMP_VERSION"; do
+          for result in "$RESULT_CHECK_RELEASABILITY" "$RESULT_UPDATE_RULE_METADATA" "$RESULT_PREPARE_RELEASE" "$RESULT_PUBLISH_GITHUB_RELEASE" "$RESULT_CREATE_RELEASE_TICKET" "$RESULT_RELEASE_IN_JIRA" "$RESULT_CREATE_INTEGRATION_TICKETS" "$RESULT_UPDATE_ANALYZERS" "$RESULT_UPDATE_ANALYSIS_AS_A_SERVICE" "$RESULT_BUMP_VERSION"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               ALL_SUCCESS=false
               break
@@ -950,11 +1018,12 @@ jobs:
             echo "  - SQS Analyzer PR: $SQS_PR_URL"
             echo "  - SQC Analyzer PR: $SQC_PR_URL"
             echo "  - Plugins Deployer PR: $PLUGINS_DEPLOYER_PR_URL"
+            echo "  - SQAA Analyzer PR: $SQAA_PR_URL"
             echo "  - Bump Version PR: $BUMP_VERSION_PR_URL"
 
             echo "## Guidance"
             if [[ "$ALL_SUCCESS" == "true" ]]; then
-              echo "- Review and merge the bump version, SQS, SQC, and Plugins Deployer PRs."
+              echo "- Review and merge the bump version, SQS, SQC, Plugins Deployer, and SQAA PRs."
               echo "- Update integration ticket statuses (ensure SQS ticket fix versions are set)."
             else
               echo "- Check failed jobs for error messages and re-run as needed."

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -42,6 +42,9 @@ jobs:
   test-update-analyzer:
     uses: ./.github/workflows/test-update-analyzer.yml
 
+  test-update-analysis-as-a-service:
+    uses: ./.github/workflows/test-update-analysis-as-a-service.yml
+
   test-update-rule-metadata:
     uses: ./.github/workflows/test-update-rule-metadata.yml
 

--- a/.github/workflows/test-update-analysis-as-a-service.yml
+++ b/.github/workflows/test-update-analysis-as-a-service.yml
@@ -1,0 +1,54 @@
+name: Test Update Analysis as a Service Action
+
+on:
+  workflow_call:
+  pull_request:
+    paths:
+      - 'update-analysis-as-a-service/**'
+      - '.github/workflows/automated-release.yml'
+      - '.github/workflows/test-update-analysis-as-a-service.yml'
+  push:
+    branches:
+      - master
+      - v*
+    paths:
+      - 'update-analysis-as-a-service/**'
+      - '.github/workflows/automated-release.yml'
+      - '.github/workflows/test-update-analysis-as-a-service.yml'
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    name: Unit Tests
+    runs-on: github-ubuntu-latest-s
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run shell unit tests
+        run: bash update-analysis-as-a-service/test_update_libs_versions_toml.sh
+
+  static-tests:
+    name: Static Tests
+    runs-on: github-ubuntu-latest-s
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Verify reusable workflow exposes SQAA integration
+        run: |
+          grep -q "sqaa-integration:" .github/workflows/automated-release.yml
+          grep -q "plugin-artifacts-sqaa:" .github/workflows/automated-release.yml
+          grep -q "sqaa-base-branch:" .github/workflows/automated-release.yml
+          grep -q "sqaa-reviewers:" .github/workflows/automated-release.yml
+          grep -q "sqaa-pull-request-url:" .github/workflows/automated-release.yml
+          grep -q "Update analyzer in Analysis as a Service" .github/workflows/automated-release.yml
+          grep -q "base-branch: .*sqaa-base-branch" .github/workflows/automated-release.yml
+          grep -q "reviewers: .*sqaa-reviewers" .github/workflows/automated-release.yml
+
+      - name: Verify action creates a pull request
+        run: |
+          grep -q "SonarSource/release-github-actions/create-pull-request@v1" update-analysis-as-a-service/action.yml
+          grep -q "SonarSource/sonar-analysis-as-a-service" update-analysis-as-a-service/action.yml

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A centralized collection of reusable GitHub Actions designed to streamline and a
 | [Resolve KTLO Epic](resolve-ktlo-epic/README.md)                        | Finds the current KTLO epic in a Jira project by matching in-progress epics against a regex pattern |
 | [Sonar Update Center Release](sonar-update-center-release/README.md)    | Updates a plugin entry in sonar-update-center-properties and creates a pull request |
 | [Update Analyzer](update-analyzer/README.md)                            | Updates an analyzer version in SonarQube or SonarCloud and creates a pull request |
+| [Update Analysis as a Service](update-analysis-as-a-service/README.md)  | Updates analyzer versions in sonar-analysis-as-a-service and creates a pull request |
 | [Update Plugins Deployer](update-plugins-deployer/README.md)            | Updates a plugin version in sonar-plugins-deployer and creates a pull request |
 | [Update Release Ticket Status](update-release-ticket-status/README.md)  | Updates the status of a Jira release ticket and can change its assignee |
 | [Update Rule Metadata](update-rule-metadata/README.md)                  | Automates updating rule metadata across all supported languages using the rule-api tooling |

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -44,6 +44,9 @@ This workflow composes several actions from this repository:
 | `plugin-name`                | Plugin name                                                                                                     | Yes      | -            |
 | `plugin-artifacts-sqs`       | Artifact identifier(s) for SQS; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqc`       | Artifact identifier(s) for SQC; falls back to `plugin-name`                                                     | No       | -            |
+| `plugin-artifacts-sqaa`      | Artifact identifier(s) for SQAA; falls back to `plugin-name`                                                    | No       | -            |
+| `sqaa-base-branch`           | Base branch for the SQAA pull request                                                                           | No       | `master`     |
+| `sqaa-reviewers`             | Comma-separated list of GitHub usernames to request a review on the SQAA pull request                           | No       | -            |
 | `use-jira-sandbox`           | Use Jira sandbox                                                                                                | No       | `true`       |
 | `is-draft-release`           | Create the GitHub release as a draft                                                                            | No       | `true`       |
 | `pm-email`                   | Product manager email to assign the release ticket after technical release                                      | Yes      | -            |
@@ -62,6 +65,7 @@ This workflow composes several actions from this repository:
 | `sq-cli-short-description`   | Short summary of SQ CLI related changes                                                                         | No       | -            |
 | `sqs-integration`            | Create SQS integration ticket and PR                                                                            | No       | `true`       |
 | `sqc-integration`            | Create SQC integration ticket and PR                                                                            | No       | `true`       |
+| `sqaa-integration`           | Create SQAA PR in sonar-analysis-as-a-service                                                                   | No       | `false`      |
 | `ktlo-jira-project-key`      | Jira project key where the KTLO epic lives. Defaults to `jira-project-key` if not provided.                    | No       | -            |
 | `ktlo-epic-name-pattern`     | Regex pattern to match the KTLO epic summary                                                                    | No       | `KTLO`       |
 | `runner-environment`         | Runner labels/environment                                                                                       | No       | `sonar-m`    |
@@ -75,9 +79,10 @@ This workflow composes several actions from this repository:
 
 ## Outputs
 
-| Output        | Description                                                |
-|---------------|------------------------------------------------------------|
-| `new-version` | The newly created Jira version name (from the Jira release job) |
+| Output                  | Description                                                |
+|-------------------------|------------------------------------------------------------|
+| `new-version`           | The newly created Jira version name (from the Jira release job) |
+| `sqaa-pull-request-url` | URL of the SQAA analyzer-update pull request               |
 
 ## Environment Variables
 

--- a/update-analysis-as-a-service/README.md
+++ b/update-analysis-as-a-service/README.md
@@ -1,0 +1,76 @@
+# Update Analysis as a Service Action
+
+This GitHub Action updates analyzer versions in `SonarSource/sonar-analysis-as-a-service` and creates a pull request.
+
+## Description
+
+The action updates `gradle/libs.versions.toml` in Analysis as a Service by:
+1. Checking out `SonarSource/sonar-analysis-as-a-service`
+2. Resolving version keys from `plugin-name` or `plugin-artifacts`
+3. Updating matching `[versions]` entries
+4. Creating a pull request with the changes using the specified GitHub token from Vault
+
+## Prerequisites
+
+The `secret-name` provided to the action must have the following permissions on `SonarSource/sonar-analysis-as-a-service`:
+
+* `contents: write`
+* `pull-requests: write`
+
+## Inputs
+
+| Input               | Description                                                                                                    | Required | Default  |
+|---------------------|----------------------------------------------------------------------------------------------------------------|----------|----------|
+| `release-version`   | The new version to set for the analyzer, e.g. `1.12.0.12345`.                                                   | `true`   |          |
+| `plugin-name`       | The language key of the plugin to update. Used in the PR title and as the default version-key source.           | `true`   |          |
+| `secret-name`       | Name of the Vault secret for a GitHub token with access to `sonar-analysis-as-a-service`.                       | `true`   |          |
+| `plugin-artifacts`  | Comma-separated analyzer artifact names to update instead of `plugin-name`.                                     | `false`  |          |
+| `base-branch`       | The base branch for the pull request.                                                                          | `false`  | `master` |
+| `draft`             | Whether to create the pull request as a draft.                                                                  | `false`  | `false`  |
+| `reviewers`         | A comma-separated list of GitHub usernames to request a review from.                                            | `false`  |          |
+| `pull-request-body` | The body of the pull request.                                                                                  | `false`  |          |
+
+## Outputs
+
+| Output             | Description                          |
+|--------------------|--------------------------------------|
+| `pull-request-url` | The URL of the created pull request. |
+
+## Version Key Resolution
+
+For each artifact, the action strips a `-enterprise` suffix and then resolves version keys in this order:
+
+1. For artifacts already starting with `sonar-` and not ending with `-plugin`, `{artifact}-plugin`
+2. For artifacts already starting with `sonar-`, the exact artifact key
+3. For other artifacts not ending with `-plugin`, `sonar-{artifact}-plugin`
+4. For other artifacts, `sonar-{artifact}`
+
+For example:
+
+* `dre` updates `sonar-dre`
+* `java` updates `sonar-java-plugin`
+* `java-symbolic-execution` updates `sonar-java-symbolic-execution-plugin`
+* `go-enterprise` updates `sonar-go`
+
+## Usage
+
+```yaml
+- name: Update Analysis as a Service
+  uses: SonarSource/release-github-actions/update-analysis-as-a-service@v1
+  with:
+    release-version: '1.12.0.12345'
+    plugin-name: 'dre'
+    secret-name: 'sonar-dre-release-automation'
+```
+
+### Updating multiple version keys
+
+```yaml
+- name: Update Analysis as a Service
+  uses: SonarSource/release-github-actions/update-analysis-as-a-service@v1
+  with:
+    release-version: '8.25.0.42802'
+    plugin-name: 'java'
+    plugin-artifacts: 'java,java-symbolic-execution'
+    secret-name: 'sonar-java-release-automation'
+```

--- a/update-analysis-as-a-service/action.yml
+++ b/update-analysis-as-a-service/action.yml
@@ -1,0 +1,91 @@
+name: 'Update Analysis as a Service'
+description: 'Updates analyzer versions in sonar-analysis-as-a-service and creates a pull request.'
+author: 'SonarSource'
+
+inputs:
+  release-version:
+    description: 'The new version to set for the analyzer (e.g., 1.12.0.12345).'
+    required: true
+  plugin-name:
+    description: 'The language key of the plugin to update. Used for PR title, commit message, and default version-key resolution.'
+    required: true
+  secret-name:
+    description: 'Name of the secret to fetch from the vault that has write access to sonar-analysis-as-a-service.'
+    required: true
+  plugin-artifacts:
+    description: 'Comma-separated list of analyzer artifact names to update instead of plugin-name.'
+    required: false
+  base-branch:
+    description: 'The base branch for the pull request.'
+    required: false
+    default: 'master'
+  draft:
+    description: 'A boolean value to control if the pull request is created as a draft. When true, the commit message is prefixed with [DO NOT MERGE].'
+    required: false
+    default: 'false'
+  reviewers:
+    description: 'A comma-separated list of GitHub usernames to request a review from.'
+    required: false
+  pull-request-body:
+    description: 'The body of the pull request.'
+    required: false
+
+outputs:
+  pull-request-url:
+    description: 'The URL of the created pull request.'
+    value: ${{ steps.create_pr.outputs.pull-request-url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get GitHub token from Vault
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@v3
+      with:
+        secrets: |
+          development/github/token/SonarSource-${{ inputs.secret-name}} token | GITHUB_TOKEN;
+
+    - name: Set commit prefix
+      id: setup_env
+      shell: bash
+      env:
+        DRAFT: ${{ inputs.draft }}
+      run: |
+        if [[ "$DRAFT" == "true" ]]; then
+          echo "commit-prefix=[DO NOT MERGE]" >> "$GITHUB_OUTPUT"
+        else
+          echo "commit-prefix=[AaaS]" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Checkout sonar-analysis-as-a-service
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: SonarSource/sonar-analysis-as-a-service
+        ref: ${{ inputs.base-branch }}
+        sparse-checkout: gradle/libs.versions.toml
+        sparse-checkout-cone-mode: false
+        fetch-depth: 0
+        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+
+    - name: Update analyzer version in Gradle version catalog
+      shell: bash
+      env:
+        LIBS_VERSIONS_TOML: gradle/libs.versions.toml
+        PLUGIN_ARTIFACTS: ${{ inputs.plugin-artifacts }}
+        PLUGIN_NAME: ${{ inputs.plugin-name }}
+        RELEASE_VERSION: ${{ inputs.release-version }}
+      run: bash ${{ github.action_path }}/update_libs_versions_toml.sh
+
+    - name: Create Pull Request
+      id: create_pr
+      uses: SonarSource/release-github-actions/create-pull-request@v1
+      with:
+        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        commit-message: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` plugins to version ${{ inputs.release-version }}'
+        title: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` to version ${{ inputs.release-version }}'
+        body: ${{ inputs.pull-request-body }}
+        base: ${{ inputs.base-branch }}
+        branch: '${{ inputs.plugin-name }}/update-aaas-${{ inputs.release-version }}'
+        draft: ${{ inputs.draft }}
+        reviewers: ${{ inputs.reviewers }}

--- a/update-analysis-as-a-service/test_update_libs_versions_toml.sh
+++ b/update-analysis-as-a-service/test_update_libs_versions_toml.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Unit tests for update_libs_versions_toml.sh
+# Run: bash update-analysis-as-a-service/test_update_libs_versions_toml.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/update_libs_versions_toml.sh"
+
+PASS=0
+FAIL=0
+
+run_test() {
+  local name="$1"
+  local expected_exit="$2"
+  shift 2
+  if "$@" >/dev/null 2>&1; then
+    actual_exit=0
+  else
+    actual_exit=$?
+  fi
+  if [[ "$actual_exit" -eq "$expected_exit" ]]; then
+    echo "OK $name"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $name (expected exit $expected_exit, got $actual_exit)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+  if grep -Fq "$pattern" "$file"; then
+    echo "OK $name"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $name (pattern not found: $pattern)"
+    echo "File contents:"
+    cat "$file"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+  if ! grep -Fq "$pattern" "$file"; then
+    echo "OK $name"
+    PASS=$((PASS+1))
+  else
+    echo "FAIL $name (pattern should not be present: $pattern)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+make_libs_versions_toml() {
+  local dir="$1"
+  mkdir -p "$dir/gradle"
+  cat > "$dir/gradle/libs.versions.toml" <<'EOF'
+[versions]
+sonar-dre = "2.3.0.12320"
+sonar-go = "1.38.0.6335"
+sonar-java = "0.0.0.1"
+sonar-java-plugin = "8.25.0.42802"
+sonar-java.plugin = "1.0.0.100"
+sonar-javaXplugin = "1.0.0.200"
+sonar-java-symbolic-execution-plugin = "8.18.0.242"
+sonar-security = "11.33.0.47162"
+sonar-python = "5.23.0.33560"
+
+[libraries]
+sonar-dre-plugin = { module = "com.sonarsource.dre:sonar-dre-plugin", version.ref = "sonar-dre" }
+sonar-go-plugin = { module = "com.sonarsource.go:sonar-go-enterprise-plugin", version.ref = "sonar-go" }
+sonar-java-plugin = { module = "org.sonarsource.java:sonar-java-plugin", version.ref = "sonar-java-plugin" }
+sonar-java-symbolic-execution-plugin = { module = "org.sonarsource.java:sonar-java-symbolic-execution-plugin", version.ref = "sonar-java-symbolic-execution-plugin" }
+sonar-security-plugin = { module = "com.sonarsource.security:sonar-security-plugin", version.ref = "sonar-security" }
+sonar-python-plugin = { module = "com.sonarsource.python:sonar-python-enterprise-plugin", version.ref = "sonar-python" }
+
+[plugins]
+sonar-dre = "com.sonarsource.dre:sonar-dre-plugin:2.3.0.12320"
+EOF
+}
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="dre" RELEASE_VERSION="2.4.0.1" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_dre=0 || actual_dre=$?
+if [[ "$actual_dre" -eq 0 ]]; then
+  assert_contains "dre version updated" "$T/gradle/libs.versions.toml" 'sonar-dre = "2.4.0.1"'
+  assert_not_contains "dre library alias unchanged" "$T/gradle/libs.versions.toml" 'sonar-dre-plugin = "2.4.0.1"'
+  assert_contains "inline coordinate outside versions unchanged" "$T/gradle/libs.versions.toml" 'sonar-dre = "com.sonarsource.dre:sonar-dre-plugin:2.3.0.12320"'
+else
+  echo "FAIL dre update failed (exit $actual_dre)"
+  FAIL=$((FAIL+3))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+special_version='1.2&3\4'
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="dre" RELEASE_VERSION="$special_version" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_special_version=0 || actual_special_version=$?
+if [[ "$actual_special_version" -eq 0 ]]; then
+  assert_contains "version with awk replacement metacharacters is written literally" "$T/gradle/libs.versions.toml" "sonar-dre = \"${special_version}\""
+else
+  echo "FAIL special version update failed (exit $actual_special_version)"
+  FAIL=$((FAIL+1))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="java" RELEASE_VERSION="9.0.0.2" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_java=0 || actual_java=$?
+if [[ "$actual_java" -eq 0 ]]; then
+  assert_contains "java plugin version updated" "$T/gradle/libs.versions.toml" 'sonar-java-plugin = "9.0.0.2"'
+  assert_contains "java family key unchanged" "$T/gradle/libs.versions.toml" 'sonar-java = "0.0.0.1"'
+  assert_not_contains "java symbolic execution unchanged" "$T/gradle/libs.versions.toml" 'sonar-java-symbolic-execution-plugin = "9.0.0.2"'
+else
+  echo "FAIL java update failed (exit $actual_java)"
+  FAIL=$((FAIL+3))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="java" PLUGIN_ARTIFACTS="sonar-java" RELEASE_VERSION="9.0.0.3" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_sonar_java=0 || actual_sonar_java=$?
+if [[ "$actual_sonar_java" -eq 0 ]]; then
+  assert_contains "sonar-prefixed java plugin version updated" "$T/gradle/libs.versions.toml" 'sonar-java-plugin = "9.0.0.3"'
+  assert_contains "sonar-prefixed java family key unchanged" "$T/gradle/libs.versions.toml" 'sonar-java = "0.0.0.1"'
+else
+  echo "FAIL sonar-prefixed java update failed (exit $actual_sonar_java)"
+  FAIL=$((FAIL+2))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="java" PLUGIN_ARTIFACTS="java,java-symbolic-execution" RELEASE_VERSION="9.1.0.3" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_multi_java=0 || actual_multi_java=$?
+if [[ "$actual_multi_java" -eq 0 ]]; then
+  assert_contains "java plugin multi update" "$T/gradle/libs.versions.toml" 'sonar-java-plugin = "9.1.0.3"'
+  assert_contains "java symbolic execution multi update" "$T/gradle/libs.versions.toml" 'sonar-java-symbolic-execution-plugin = "9.1.0.3"'
+else
+  echo "FAIL multi java update failed (exit $actual_multi_java)"
+  FAIL=$((FAIL+2))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="go" PLUGIN_ARTIFACTS="go-enterprise" RELEASE_VERSION="1.39.0.4" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_go=0 || actual_go=$?
+if [[ "$actual_go" -eq 0 ]]; then
+  assert_contains "go enterprise suffix stripped" "$T/gradle/libs.versions.toml" 'sonar-go = "1.39.0.4"'
+else
+  echo "FAIL go update failed (exit $actual_go)"
+  FAIL=$((FAIL+1))
+fi
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="java" PLUGIN_ARTIFACTS="sonar-java.plugin" RELEASE_VERSION="1.0.0.300" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_literal=0 || actual_literal=$?
+if [[ "$actual_literal" -eq 0 ]]; then
+  assert_contains "regex metachar key updated literally" "$T/gradle/libs.versions.toml" 'sonar-java.plugin = "1.0.0.300"'
+  assert_contains "similar key not updated by regex" "$T/gradle/libs.versions.toml" 'sonar-javaXplugin = "1.0.0.200"'
+else
+  echo "FAIL literal key update failed (exit $actual_literal)"
+  FAIL=$((FAIL+2))
+fi
+rm -rf "$T"
+
+for blank_artifacts in " , " ","; do
+  T=$(mktemp -d)
+  make_libs_versions_toml "$T"
+  LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="python" PLUGIN_ARTIFACTS="$blank_artifacts" RELEASE_VERSION="5.24.0.5" \
+    bash "$SCRIPT" >/dev/null 2>&1 && actual_blank_artifacts=0 || actual_blank_artifacts=$?
+  if [[ "$actual_blank_artifacts" -eq 0 ]]; then
+    assert_contains "blank artifacts '$blank_artifacts' fall back to plugin name" "$T/gradle/libs.versions.toml" 'sonar-python = "5.24.0.5"'
+  else
+    echo "FAIL blank artifacts '$blank_artifacts' fallback failed (exit $actual_blank_artifacts)"
+    FAIL=$((FAIL+1))
+  fi
+  rm -rf "$T"
+done
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+run_test "unknown plugin fails" 1 \
+  bash -c "LIBS_VERSIONS_TOML='$T/gradle/libs.versions.toml' PLUGIN_NAME='nonexistent-plugin-xyz' RELEASE_VERSION='1.0.0.1' bash '$SCRIPT'"
+rm -rf "$T"
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/update-analysis-as-a-service/update_libs_versions_toml.sh
+++ b/update-analysis-as-a-service/update_libs_versions_toml.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Updates analyzer version keys in gradle/libs.versions.toml for Analysis as a Service.
+#
+# Environment variables (required):
+#   LIBS_VERSIONS_TOML - path to gradle/libs.versions.toml
+#   PLUGIN_NAME        - plugin name used when PLUGIN_ARTIFACTS is empty
+#   RELEASE_VERSION    - new version string (e.g. 1.2.3.45678)
+#
+# Environment variables (optional):
+#   PLUGIN_ARTIFACTS   - comma-separated artifact names to update instead of PLUGIN_NAME
+
+set -euo pipefail
+
+LIBS_VERSIONS_TOML="${LIBS_VERSIONS_TOML:-gradle/libs.versions.toml}"
+RELEASE_VERSION="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+PLUGIN_NAME="${PLUGIN_NAME:?PLUGIN_NAME is required}"
+PLUGIN_ARTIFACTS="${PLUGIN_ARTIFACTS:-}"
+
+trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+candidate_keys() {
+  local artifact="$1"
+  local base="${artifact%-enterprise}"
+
+  if [[ "$base" == sonar-* ]]; then
+    if [[ "$base" != *-plugin ]]; then
+      printf '%s-plugin\n' "$base"
+    fi
+    printf '%s\n' "$base"
+    return
+  fi
+
+  if [[ "$base" != *-plugin ]]; then
+    printf 'sonar-%s-plugin\n' "$base"
+  fi
+  printf 'sonar-%s\n' "$base"
+}
+
+find_version_key() {
+  local artifact="$1"
+  local key
+
+  while IFS= read -r key; do
+    if VERSION_CATALOG_KEY="$key" awk '
+      BEGIN { key = ENVIRON["VERSION_CATALOG_KEY"] }
+      function trim(value) {
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        return value
+      }
+      /^\[versions\][[:space:]]*$/ { in_versions = 1; next }
+      /^\[/ { in_versions = 0 }
+      in_versions {
+        split($0, parts, "=")
+        if (trim(parts[1]) == key && $0 ~ /^[^=]+=[[:space:]]*"[^"]*"/) {
+          found = 1
+        }
+      }
+      END { exit found ? 0 : 1 }
+    ' "$LIBS_VERSIONS_TOML"; then
+      printf '%s' "$key"
+      return 0
+    fi
+  done < <(candidate_keys "$artifact")
+
+  return 1
+}
+
+update_version_key() {
+  local key="$1"
+  local tmp
+
+  tmp=$(mktemp)
+  VERSION_CATALOG_KEY="$key" RELEASE_VERSION="$RELEASE_VERSION" awk '
+    BEGIN {
+      key = ENVIRON["VERSION_CATALOG_KEY"]
+      version = ENVIRON["RELEASE_VERSION"]
+    }
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    /^\[versions\][[:space:]]*$/ { in_versions = 1; print; next }
+    /^\[/ { in_versions = 0 }
+    in_versions {
+      split($0, parts, "=")
+    }
+    in_versions && trim(parts[1]) == key && $0 ~ /^[^=]+=[[:space:]]*"[^"]*"/ && match($0, /"[^"]*"/) {
+      $0 = substr($0, 1, RSTART - 1) "\"" version "\"" substr($0, RSTART + RLENGTH)
+    }
+    { print }
+  ' "$LIBS_VERSIONS_TOML" > "$tmp"
+  mv "$tmp" "$LIBS_VERSIONS_TOML"
+  echo "Updated ${key} to ${RELEASE_VERSION}"
+}
+
+if [[ ! -f "$LIBS_VERSIONS_TOML" ]]; then
+  echo "::error::${LIBS_VERSIONS_TOML} not found." >&2
+  exit 1
+fi
+
+declare -a artifacts=()
+if [[ -n "$PLUGIN_ARTIFACTS" ]]; then
+  declare -a raw_artifacts=()
+  IFS=',' read -ra raw_artifacts <<< "$PLUGIN_ARTIFACTS"
+  for raw_artifact in "${raw_artifacts[@]}"; do
+    artifact="$(trim "$raw_artifact")"
+    if [[ -n "$artifact" ]]; then
+      artifacts+=("$artifact")
+    fi
+  done
+fi
+
+if [[ "${#artifacts[@]}" -eq 0 ]]; then
+  artifacts=("$PLUGIN_NAME")
+fi
+
+declare -a updated_keys=()
+for artifact in "${artifacts[@]}"; do
+  artifact="$(trim "$artifact")"
+  if [[ -z "$artifact" ]]; then
+    continue
+  fi
+
+  if ! key="$(find_version_key "$artifact")"; then
+    echo "::error::No version key found for artifact '${artifact}' in ${LIBS_VERSIONS_TOML}. Tried: $(candidate_keys "$artifact" | paste -sd ', ' -)" >&2
+    exit 1
+  fi
+
+  already_updated=false
+  if [[ "${#updated_keys[@]}" -gt 0 ]]; then
+    for updated_key in "${updated_keys[@]}"; do
+      if [[ "$updated_key" == "$key" ]]; then
+        already_updated=true
+        break
+      fi
+    done
+  fi
+
+  if [[ "$already_updated" == "false" ]]; then
+    update_version_key "$key"
+    updated_keys+=("$key")
+  fi
+done
+
+if [[ "${#updated_keys[@]}" -eq 0 ]]; then
+  echo "::error::No plugin artifacts were provided to update." >&2
+  exit 1
+fi
+
+echo "Showing diff:"
+git --no-pager diff "$LIBS_VERSIONS_TOML" 2>/dev/null || true


### PR DESCRIPTION
## Summary
Add an optional SQAA integration path to the reusable automated release workflow so releases can open an Analysis as a Service update PR.

## Changes
- Add update-analysis-as-a-service composite action to update gradle/libs.versions.toml in sonar-analysis-as-a-service.
- Add sqaa-integration and plugin-artifacts-sqaa inputs plus sqaa-pull-request-url output to the reusable release workflow.
- Add shell tests, workflow coverage, and documentation for the new action.
