### PR TITLE
GHA-341 Add option to disable freeze/unfreeze Slack notification for automated release

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -138,6 +138,11 @@ on:
         required: false
         type: boolean
         default: true
+      freeze-branch-slack-notification:
+        description: "Send Slack notification when freezing/unfreezing the branch"
+        required: false
+        type: boolean
+        default: true
       check-releasability:
         description: "Check the releasability status after freezing the branch"
         required: false
@@ -240,7 +245,7 @@ jobs:
         with:
           branch: ${{ inputs.branch }}
           freeze: true
-          slack-channel: ${{ inputs.slack-channel }}
+          slack-channel: ${{ inputs.freeze-branch-slack-notification == true && inputs.slack-channel || '' }}
       - name: Summary
         if: ${{ inputs.verbose }}
         shell: bash
@@ -540,7 +545,7 @@ jobs:
         with:
           branch: ${{ inputs.branch }}
           freeze: false
-          slack-channel: ${{ inputs.slack-channel }}
+          slack-channel: ${{ inputs.freeze-branch-slack-notification == true && inputs.slack-channel || '' }}
       - name: Summary
         if: ${{ inputs.verbose }}
         shell: bash

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -68,6 +68,7 @@ This workflow composes several actions from this repository:
 | `release-process`            | Release process documentation URL                                                                               | No       | General page |
 | `verbose`                    | When `true`, posts per-job summaries and a final run summary                                                    | No       | `false`      |
 | `freeze-branch`              | When `true`, locks the target branch during the release and unlocks it after publishing                         | No       | `true`       |
+| `freeze-branch-slack-notification` | When `false`, suppresses Slack notifications for the freeze and unfreeze steps                           | No       | `true`       |
 | `check-releasability`        | When `true`, verifies the releasability status on the branch before proceeding                                  | No       | `true`       |
 | `slack-channel`              | Slack channel to notify when locking/unlocking the branch                                                       | No       | -            |
 | `release-artifacts-public`   | Newline-separated Repox paths from public repositories to attach to the GitHub release                          | No       | -            |


### PR DESCRIPTION
----
## Summary by Gitar

- **New workflow input:**
  - Added `freeze-branch-slack-notification` boolean input to `.github/workflows/automated-release.yml` to toggle notifications.
- **Logic updates:**
  - Modified branch freeze and unfreeze steps to conditionally clear `slack-channel` when notifications are disabled.
- **Documentation:**
  - Added `freeze-branch-slack-notification` description to `docs/AUTOMATED_RELEASE.md`.

<sub>This will update automatically on new commits.</sub>