### PR TITLE
GHA-342 Integrate into SQAA by default when integrating into SQC

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -127,10 +127,10 @@ on:
         type: boolean
         default: true
       sqaa-integration:
-        description: "Create SQAA PR in sonar-analysis-as-a-service"
+        description: "Create SQAA PR in sonar-analysis-as-a-service when sqc-integration is true"
         required: false
         type: boolean
-        default: false
+        default: true
       sqc-plugins-deployer-integration:
         description: "Also create a PR in sonar-plugins-deployer when sqc-integration is true. Disabled by default during the transition period."
         required: false
@@ -898,7 +898,7 @@ jobs:
     runs-on: ${{ inputs.runner-environment }}
     needs: [ prepare-release ]
     if: |
-      inputs.sqaa-integration &&
+      inputs.sqc-integration && inputs.sqaa-integration &&
       !cancelled() &&
       needs.prepare-release.result == 'success'
     permissions:

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -65,7 +65,7 @@ This workflow composes several actions from this repository:
 | `sq-cli-short-description`   | Short summary of SQ CLI related changes                                                                         | No       | -            |
 | `sqs-integration`            | Create SQS integration ticket and PR                                                                            | No       | `true`       |
 | `sqc-integration`            | Create SQC integration ticket and PR                                                                            | No       | `true`       |
-| `sqaa-integration`           | Create SQAA PR in sonar-analysis-as-a-service                                                                   | No       | `false`      |
+| `sqaa-integration`           | Create SQAA PR in sonar-analysis-as-a-service. Runs when both this and `sqc-integration` are true. Skipped silently if the analyzer is not yet onboarded to SQAA. | No       | `true`       |
 | `ktlo-jira-project-key`      | Jira project key where the KTLO epic lives. Defaults to `jira-project-key` if not provided.                    | No       | -            |
 | `ktlo-epic-name-pattern`     | Regex pattern to match the KTLO epic summary                                                                    | No       | `KTLO`       |
 | `runner-environment`         | Runner labels/environment                                                                                       | No       | `sonar-m`    |

--- a/update-analysis-as-a-service/README.md
+++ b/update-analysis-as-a-service/README.md
@@ -36,6 +36,10 @@ The `secret-name` provided to the action must have the following permissions on 
 |--------------------|--------------------------------------|
 | `pull-request-url` | The URL of the created pull request. |
 
+## Unonboarded Analyzers
+
+If no matching version key is found for an artifact in `gradle/libs.versions.toml`, the artifact is **skipped with a warning** — the action does not fail. When all artifacts are skipped (none found), the action exits cleanly with no PR created. This allows the SQAA integration to be enabled by default for all analyzers without breaking ones not yet onboarded to `sonar-analysis-as-a-service`.
+
 ## Version Key Resolution
 
 For each artifact, the action strips a `-enterprise` suffix and then resolves version keys in this order:

--- a/update-analysis-as-a-service/test_update_libs_versions_toml.sh
+++ b/update-analysis-as-a-service/test_update_libs_versions_toml.sh
@@ -191,8 +191,21 @@ done
 
 T=$(mktemp -d)
 make_libs_versions_toml "$T"
-run_test "unknown plugin fails" 1 \
+run_test "unknown plugin is skipped without failing" 0 \
   bash -c "LIBS_VERSIONS_TOML='$T/gradle/libs.versions.toml' PLUGIN_NAME='nonexistent-plugin-xyz' RELEASE_VERSION='1.0.0.1' bash '$SCRIPT'"
+assert_contains "unknown plugin leaves toml unchanged" "$T/gradle/libs.versions.toml" 'sonar-python = "5.23.0.33560"'
+rm -rf "$T"
+
+T=$(mktemp -d)
+make_libs_versions_toml "$T"
+LIBS_VERSIONS_TOML="$T/gradle/libs.versions.toml" PLUGIN_NAME="python" PLUGIN_ARTIFACTS="python,nonexistent-plugin-xyz" RELEASE_VERSION="5.24.0.6" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_mixed=0 || actual_mixed=$?
+if [[ "$actual_mixed" -eq 0 ]]; then
+  assert_contains "mixed artifacts: known key updated" "$T/gradle/libs.versions.toml" 'sonar-python = "5.24.0.6"'
+else
+  echo "FAIL mixed artifacts: unknown should be skipped, known updated (exit $actual_mixed)"
+  FAIL=$((FAIL+1))
+fi
 rm -rf "$T"
 
 echo ""

--- a/update-analysis-as-a-service/update_libs_versions_toml.sh
+++ b/update-analysis-as-a-service/update_libs_versions_toml.sh
@@ -129,8 +129,8 @@ for artifact in "${artifacts[@]}"; do
   fi
 
   if ! key="$(find_version_key "$artifact")"; then
-    echo "::error::No version key found for artifact '${artifact}' in ${LIBS_VERSIONS_TOML}. Tried: $(candidate_keys "$artifact" | paste -sd ', ' -)" >&2
-    exit 1
+    echo "::warning::No version key found for artifact '${artifact}' in ${LIBS_VERSIONS_TOML}. Tried: $(candidate_keys "$artifact" | paste -sd ', ' -). Skipping." >&2
+    continue
   fi
 
   already_updated=false
@@ -150,8 +150,8 @@ for artifact in "${artifacts[@]}"; do
 done
 
 if [[ "${#updated_keys[@]}" -eq 0 ]]; then
-  echo "::error::No plugin artifacts were provided to update." >&2
-  exit 1
+  echo "::warning::No version keys were updated — analyzer likely not yet onboarded to SQAA. No PR will be created." >&2
+  exit 0
 fi
 
 echo "Showing diff:"


### PR DESCRIPTION
## Summary

- `sqaa-integration` input defaults to `true` in the automated-release workflow
- The `update-analysis-as-a-service` job is gated on `sqc-integration && sqaa-integration`, so SQAA runs by default alongside SQC — either flag can be set to `false` to opt out
- Missing version key in `gradle/libs.versions.toml` is now non-fatal: the artifact is skipped with a `::warning::` annotation and no PR is created, allowing unonboarded analyzers to release without failure

## Test plan

- [ ] Run `bash update-analysis-as-a-service/test_update_libs_versions_toml.sh` — all 19 tests pass
- [ ] Trigger an automated release for an analyzer **not** in SQAA's toml — `update-analysis-as-a-service` job should pass with a warning and no PR created
- [ ] Trigger an automated release for an analyzer **in** SQAA's toml — SQAA PR created as usual
- [ ] Set `sqaa-integration: false` — SQAA job is skipped even when `sqc-integration: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)