### PR TITLE
GHA-342 Fix S8707 path traversal vulnerabilities in CLI path arguments

### DIFF
--- a/sonar-update-center-release/test_update.py
+++ b/sonar-update-center-release/test_update.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from update import safe_path
+
+
+class TestSafePath(unittest.TestCase):
+    def test_valid_path_accepted(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, 'properties.txt')
+            self.assertEqual(safe_path(p, base=d), os.path.realpath(p))
+
+    def test_traversal_exits(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit) as cm:
+                safe_path('../../etc/passwd', base=d)
+            self.assertEqual(cm.exception.code, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/sonar-update-center-release/update.py
+++ b/sonar-update-center-release/update.py
@@ -1,5 +1,16 @@
 import argparse
+import os
 import sys
+
+
+def safe_path(path, base=None):
+    """Resolve path and ensure it stays within base (cwd by default). Exits 1 if it escapes."""
+    base_dir = os.path.realpath(base or os.getcwd())
+    resolved = os.path.realpath(os.path.join(base_dir, path))
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        print(f'ERROR: path {path!r} is outside the allowed directory', file=sys.stderr)
+        sys.exit(1)
+    return resolved
 
 # The entire file was written by AI.
 
@@ -17,6 +28,7 @@ def main():
     parser.add_argument('--changelogUrl', required=True, help='Changelog URL')
     parser.add_argument('--downloadUrl', required=True, help='Download URL')
     args = parser.parse_args()
+    args.file = safe_path(args.file)
 
     # First pass: find the current publicVersions value to move it to archivedVersions
     old_public_version = None

--- a/test-fixtures/jira/cleanup.py
+++ b/test-fixtures/jira/cleanup.py
@@ -14,7 +14,7 @@ import argparse
 import json
 import sys
 
-from jira_client import get_jira_instance, eprint
+from jira_client import get_jira_instance, eprint, safe_path
 from jira.exceptions import JIRAError
 
 
@@ -57,6 +57,7 @@ def main():
     issue_keys = [k for k in args.issue_keys.split(',') if k] if args.issue_keys else []
 
     if args.state_file:
+        args.state_file = safe_path(args.state_file)
         try:
             with open(args.state_file) as f:
                 state = json.load(f)

--- a/test-fixtures/jira/cleanup_ktlo.py
+++ b/test-fixtures/jira/cleanup_ktlo.py
@@ -9,7 +9,7 @@ Usage:
 import argparse
 import json
 
-from jira_client import get_jira_instance, eprint
+from jira_client import get_jira_instance, eprint, safe_path
 from jira.exceptions import JIRAError
 
 
@@ -30,6 +30,7 @@ def main():
     parser.add_argument("--jira-url", required=True)
     parser.add_argument("--state-file", required=True)
     args = parser.parse_args()
+    args.state_file = safe_path(args.state_file)
 
     jira = get_jira_instance(args.jira_url)
 

--- a/test-fixtures/jira/jira_client.py
+++ b/test-fixtures/jira/jira_client.py
@@ -13,6 +13,16 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
+def safe_path(path, base=None):
+    """Resolve path and ensure it stays within base (cwd by default). Exits 1 if it escapes."""
+    base_dir = os.path.realpath(base or os.getcwd())
+    resolved = os.path.realpath(os.path.join(base_dir, path))
+    if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+        print(f'ERROR: path {path!r} is outside the allowed directory', file=sys.stderr)
+        sys.exit(1)
+    return resolved
+
+
 def get_jira_instance(jira_url):
     """
     Initializes and returns a JIRA client instance.

--- a/test-fixtures/jira/setup.py
+++ b/test-fixtures/jira/setup.py
@@ -14,7 +14,7 @@ import json
 import os
 import sys
 
-from jira_client import get_jira_instance, eprint
+from jira_client import get_jira_instance, eprint, safe_path
 from config import VERSION_PREFIX, ISSUE_TYPES
 
 STATE_FILE_DEFAULT = "/tmp/jira-fixtures.json"
@@ -60,6 +60,7 @@ def main():
     parser.add_argument("--jira-url", required=True, help="URL of the Jira instance.")
     parser.add_argument("--state-file", default=STATE_FILE_DEFAULT, help="Path to write state JSON for cleanup.")
     args = parser.parse_args()
+    args.state_file = safe_path(args.state_file)
 
     jira = get_jira_instance(args.jira_url)
 

--- a/test-fixtures/jira/setup_ktlo.py
+++ b/test-fixtures/jira/setup_ktlo.py
@@ -16,7 +16,7 @@ import json
 import os
 import sys
 
-from jira_client import get_jira_instance, eprint
+from jira_client import get_jira_instance, eprint, safe_path
 
 STATE_FILE_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "jira-ktlo-fixtures.json")
 
@@ -51,6 +51,7 @@ def main():
     parser.add_argument("--jira-url", required=True)
     parser.add_argument("--state-file", default=STATE_FILE_DEFAULT)
     args = parser.parse_args()
+    args.state_file = safe_path(args.state_file)
 
     jira = get_jira_instance(args.jira_url)
     run_id = args.run_id

--- a/test-fixtures/jira/test_jira_client.py
+++ b/test-fixtures/jira/test_jira_client.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from jira_client import get_jira_instance, eprint
+from jira_client import get_jira_instance, eprint, safe_path
 
 
 class TestEprint(unittest.TestCase):
@@ -81,6 +81,21 @@ class TestGetJiraInstance(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm:
             get_jira_instance('https://test.atlassian.net/')
         self.assertEqual(cm.exception.code, 1)
+
+
+class TestSafePath(unittest.TestCase):
+    def test_valid_path_returns_resolved(self):
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, 'state.json')
+            self.assertEqual(safe_path(p, base=d), os.path.realpath(p))
+
+    def test_traversal_exits(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(SystemExit) as cm:
+                safe_path('../../etc/passwd', base=d)
+            self.assertEqual(cm.exception.code, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- Fixes all 7 open `pythonsecurity:S8707` (SECURITY/HIGH) vulnerabilities on `master`
- Adds a `safe_path()` helper that resolves a path and ensures it stays within the working directory before any `open()` call
- Shared via `jira_client.py` for the 4 Jira fixture scripts; inlined in `update.py` (standalone)
- Closes / supersedes #159 (SonarCloud Remediation Agent PR that only covered 3 of the 7 sinks and had an off-by-a-separator bug in its containment check)

## Test plan

- [ ] All 9 unit tests in `test-fixtures/jira/test_jira_client.py` pass (includes 2 new `safe_path` tests)
- [ ] 2 unit tests in `sonar-update-center-release/test_update.py` pass
- [ ] SonarCloud analysis on this PR shows all 7 S8707 issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)