### PR TITLE
GHA-344 Extract common update-version-pr action from the three update-X wrappers

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -56,3 +56,6 @@ jobs:
 
   test-create-pull-request:
     uses: ./.github/workflows/test-create-pull-request.yml
+
+  test-update-version-pr:
+    uses: ./.github/workflows/test-update-version-pr.yml

--- a/.github/workflows/test-update-version-pr.yml
+++ b/.github/workflows/test-update-version-pr.yml
@@ -1,0 +1,119 @@
+name: Test Update Version PR Action
+
+on:
+  workflow_call:
+  pull_request:
+    paths:
+      - 'update-version-pr/**'
+      - '.github/workflows/test-update-version-pr.yml'
+  push:
+    branches:
+      - branch-*
+    paths:
+      - 'update-version-pr/**'
+      - '.github/workflows/test-update-version-pr.yml'
+  workflow_dispatch:
+
+jobs:
+  schema-validation:
+    name: Schema Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Verify composite action type
+        run: |
+          set -euo pipefail
+          if grep -q 'using: .composite.' update-version-pr/action.yml; then
+            echo "PASS: using: composite found"
+          else
+            echo "FAIL: using: composite not found"
+            exit 1
+          fi
+
+      - name: Verify expected inputs exist
+        run: |
+          set -euo pipefail
+          INPUTS=(
+            secret-name target-repo sparse-paths base-branch
+            edit-script edit-env
+            commit-message title body branch draft reviewers
+          )
+          for input in "${INPUTS[@]}"; do
+            if grep -q "^  ${input}:" update-version-pr/action.yml; then
+              echo "PASS: input '${input}' found"
+            else
+              echo "FAIL: input '${input}' not found"
+              exit 1
+            fi
+          done
+
+      - name: Verify expected outputs exist
+        run: |
+          set -euo pipefail
+          OUTPUTS=(pull-request-url)
+          for output in "${OUTPUTS[@]}"; do
+            if grep -q "^  ${output}:" update-version-pr/action.yml; then
+              echo "PASS: output '${output}' found"
+            else
+              echo "FAIL: output '${output}' not found"
+              exit 1
+            fi
+          done
+
+      - name: Verify bash steps use set -euo pipefail
+        run: |
+          set -euo pipefail
+          BASH_STEPS=$(grep -c 'shell: bash' update-version-pr/action.yml)
+          PIPEFAIL_COUNT=$(grep -c 'set -euo pipefail' update-version-pr/action.yml)
+          echo "Bash steps: ${BASH_STEPS}, pipefail occurrences: ${PIPEFAIL_COUNT}"
+          if [ "$PIPEFAIL_COUNT" -ge "$BASH_STEPS" ]; then
+            echo "PASS: all bash steps use set -euo pipefail"
+          else
+            echo "FAIL: not all bash steps use set -euo pipefail"
+            exit 1
+          fi
+
+      - name: Verify inputs are passed via env (no direct interpolation in run blocks)
+        env:
+          PATTERN: '\$\{\{ inputs\.'
+        run: |
+          set -euo pipefail
+          in_run_block=false
+          found_violation=false
+          while IFS= read -r line; do
+            if echo "$line" | grep -qE '^\s+run: \|'; then
+              in_run_block=true
+              continue
+            fi
+            if $in_run_block && echo "$line" | grep -qE '^\s{4,6}[a-z]'; then
+              in_run_block=false
+            fi
+            if $in_run_block && echo "$line" | grep -qE "$PATTERN"; then
+              if ! echo "$line" | grep -qE '^\s*#'; then
+                echo "FAIL: direct input interpolation in run block: $line"
+                found_violation=true
+              fi
+            fi
+          done < update-version-pr/action.yml
+          if $found_violation; then
+            exit 1
+          else
+            echo "PASS: no direct input interpolation in run blocks"
+          fi
+
+      - name: Summary
+        run: echo "All schema checks passed"
+
+  unit-tests:
+    name: Unit Tests (update-analyzer edit script)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Run update_build_gradle.sh tests
+        run: bash update-analyzer/test_update_build_gradle.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A centralized collection of reusable GitHub Actions designed to streamline and a
 | [Update Analyzer](update-analyzer/README.md)                            | Updates an analyzer version in SonarQube or SonarCloud and creates a pull request |
 | [Update Analysis as a Service](update-analysis-as-a-service/README.md)  | Updates analyzer versions in sonar-analysis-as-a-service and creates a pull request |
 | [Update Plugins Deployer](update-plugins-deployer/README.md)            | Updates a plugin version in sonar-plugins-deployer and creates a pull request |
+| [Update Version PR](update-version-pr/README.md)                        | Shared wrapper used by the three update actions above: vault, checkout, run edit script, create PR |
 | [Update Release Ticket Status](update-release-ticket-status/README.md)  | Updates the status of a Jira release ticket and can change its assignee |
 | [Update Rule Metadata](update-rule-metadata/README.md)                  | Automates updating rule metadata across all supported languages using the rule-api tooling |
 

--- a/update-analysis-as-a-service/action.yml
+++ b/update-analysis-as-a-service/action.yml
@@ -38,54 +38,36 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Get GitHub token from Vault
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
-      with:
-        secrets: |
-          development/github/token/SonarSource-${{ inputs.secret-name}} token | GITHUB_TOKEN;
-
     - name: Set commit prefix
       id: setup_env
       shell: bash
       env:
         DRAFT: ${{ inputs.draft }}
       run: |
+        set -euo pipefail
         if [[ "$DRAFT" == "true" ]]; then
           echo "commit-prefix=[DO NOT MERGE]" >> "$GITHUB_OUTPUT"
         else
           echo "commit-prefix=[AaaS]" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Checkout sonar-analysis-as-a-service
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: SonarSource/sonar-analysis-as-a-service
-        ref: ${{ inputs.base-branch }}
-        sparse-checkout: gradle/libs.versions.toml
-        sparse-checkout-cone-mode: false
-        fetch-depth: 0
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-
-    - name: Update analyzer version in Gradle version catalog
-      shell: bash
-      env:
-        LIBS_VERSIONS_TOML: gradle/libs.versions.toml
-        PLUGIN_ARTIFACTS: ${{ inputs.plugin-artifacts }}
-        PLUGIN_NAME: ${{ inputs.plugin-name }}
-        RELEASE_VERSION: ${{ inputs.release-version }}
-      run: bash ${{ github.action_path }}/update_libs_versions_toml.sh
-
-    - name: Create Pull Request
+    - name: Update version and create pull request
       id: create_pr
-      uses: SonarSource/release-github-actions/create-pull-request@v1
+      uses: SonarSource/release-github-actions/update-version-pr@v1
       with:
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        secret-name: ${{ inputs.secret-name }}
+        target-repo: SonarSource/sonar-analysis-as-a-service
+        sparse-paths: gradle/libs.versions.toml
+        base-branch: ${{ inputs.base-branch }}
+        edit-script: ${{ github.action_path }}/update_libs_versions_toml.sh
+        edit-env: |
+          LIBS_VERSIONS_TOML=gradle/libs.versions.toml
+          PLUGIN_NAME=${{ inputs.plugin-name }}
+          PLUGIN_ARTIFACTS=${{ inputs.plugin-artifacts }}
+          RELEASE_VERSION=${{ inputs.release-version }}
         commit-message: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` plugins to version ${{ inputs.release-version }}'
         title: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` to version ${{ inputs.release-version }}'
         body: ${{ inputs.pull-request-body }}
-        base: ${{ inputs.base-branch }}
         branch: '${{ inputs.plugin-name }}/update-aaas-${{ inputs.release-version }}'
         draft: ${{ inputs.draft }}
         reviewers: ${{ inputs.reviewers }}

--- a/update-analyzer/action.yml
+++ b/update-analyzer/action.yml
@@ -41,84 +41,48 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Get GitHub token from Vault
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
-      with:
-        secrets: |
-          development/github/token/SonarSource-${{ inputs.secret-name}} token | GITHUB_TOKEN;
-
-    - name: Set up environment
+    - name: Resolve target repository and set commit prefix
       id: setup_env
       shell: bash
       env:
         TICKET_KEY: ${{ inputs.ticket-key }}
         DRAFT: ${{ inputs.draft }}
       run: |
+        set -euo pipefail
         if [[ "$TICKET_KEY" == SONAR-* ]]; then
-          echo "PRODUCT_REPOSITORY=sonar-enterprise" >> $GITHUB_ENV
-          echo "BUILD_GRADLE_FILE=build.gradle" >> $GITHUB_ENV
+          echo "target-repo=SonarSource/sonar-enterprise" >> "$GITHUB_OUTPUT"
+          echo "build-gradle-file=build.gradle" >> "$GITHUB_OUTPUT"
         elif [[ "$TICKET_KEY" == SC-* ]]; then
-          echo "PRODUCT_REPOSITORY=sonarcloud-core" >> $GITHUB_ENV
-          echo "BUILD_GRADLE_FILE=private/edition-sonarcloud/build.gradle" >> $GITHUB_ENV
+          echo "target-repo=SonarSource/sonarcloud-core" >> "$GITHUB_OUTPUT"
+          echo "build-gradle-file=private/edition-sonarcloud/build.gradle" >> "$GITHUB_OUTPUT"
         else
           echo "::error::Invalid ticket format. Must start with SONAR- or SC-."
           exit 1
         fi
 
         if [[ "$DRAFT" == "true" ]]; then
-          echo "commit-prefix=[DO NOT MERGE]" >> $GITHUB_OUTPUT
+          echo "commit-prefix=[DO NOT MERGE]" >> "$GITHUB_OUTPUT"
         else
-          echo "commit-prefix=$TICKET_KEY" >> $GITHUB_OUTPUT
+          echo "commit-prefix=$TICKET_KEY" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Checkout target repository
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: SonarSource/${{ env.PRODUCT_REPOSITORY }}
-        ref: ${{ inputs.base-branch }}
-        sparse-checkout: ${{ env.BUILD_GRADLE_FILE }}
-        sparse-checkout-cone-mode: false
-        fetch-depth: 0
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-
-    - name: Update analyzer version in build file
-      shell: bash
-      env:
-        PLUGIN_ARTIFACTS: ${{ inputs.plugin-artifacts }}
-        PLUGIN_NAME: ${{ inputs.plugin-name }}
-        RELEASE_VERSION: ${{ inputs.release-version }}
-      run: |
-        set -euo pipefail
-        # Prepare the list of plugins to update
-        if [[ -n "$PLUGIN_ARTIFACTS" ]]; then
-          echo "Using plugin-artifacts: $PLUGIN_ARTIFACTS"
-          IFS=',' read -ra PLUGINS <<< "$PLUGIN_ARTIFACTS"
-        else
-          echo "Using plugin-name: $PLUGIN_NAME"
-          PLUGINS=("${PLUGIN_NAME}.*")
-        fi
-
-        # Update each plugin
-        for plugin in "${PLUGINS[@]}"; do
-          plugin=$(echo "$plugin" | xargs)
-          echo "Updating analyzer version in ${{ env.BUILD_GRADLE_FILE }} for plugin $plugin"
-          sed -i "s/\(:sonar-$plugin-plugin:\)[0-9.]*/\1$RELEASE_VERSION/g" ${{ env.BUILD_GRADLE_FILE }}
-        done
-
-        echo "Showing diff:"
-        git --no-pager diff ${{ env.BUILD_GRADLE_FILE }}
-
-    - name: Create Pull Request
+    - name: Update version and create pull request
       id: create_pr
-      uses: SonarSource/release-github-actions/create-pull-request@v1
+      uses: SonarSource/release-github-actions/update-version-pr@v1
       with:
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        secret-name: ${{ inputs.secret-name }}
+        target-repo: ${{ steps.setup_env.outputs.target-repo }}
+        sparse-paths: ${{ steps.setup_env.outputs.build-gradle-file }}
+        base-branch: ${{ inputs.base-branch }}
+        edit-script: ${{ github.action_path }}/update_build_gradle.sh
+        edit-env: |
+          BUILD_GRADLE_FILE=${{ steps.setup_env.outputs.build-gradle-file }}
+          PLUGIN_NAME=${{ inputs.plugin-name }}
+          PLUGIN_ARTIFACTS=${{ inputs.plugin-artifacts }}
+          RELEASE_VERSION=${{ inputs.release-version }}
         commit-message: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` plugins to version ${{ inputs.release-version }}'
         title: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` to version ${{ inputs.release-version }}'
         body: ${{ inputs.pull-request-body }}
-        base: ${{ inputs.base-branch }}
         branch: '${{ inputs.plugin-name }}/update-analyzer-${{ inputs.release-version }}'
         draft: ${{ inputs.draft }}
         reviewers: ${{ inputs.reviewers }}

--- a/update-analyzer/test_update_build_gradle.sh
+++ b/update-analyzer/test_update_build_gradle.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Unit tests for update_build_gradle.sh
+# Run: bash test_update_build_gradle.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/update_build_gradle.sh"
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+  if grep -q "$pattern" "$file"; then
+    echo "✅ $name"
+    PASS=$((PASS+1))
+  else
+    echo "❌ $name (pattern not found: $pattern)"
+    echo "   File contents:"
+    cat "$file"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+assert_not_contains() {
+  local name="$1"
+  local file="$2"
+  local pattern="$3"
+  if ! grep -q "$pattern" "$file"; then
+    echo "✅ $name"
+    PASS=$((PASS+1))
+  else
+    echo "❌ $name (pattern unexpectedly found: $pattern)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+make_fixture() {
+  cat > "$1" <<'EOF'
+dependencies {
+    compile ":sonar-java-plugin:1.0.0"
+    compile ":sonar-python-plugin:2.3.4"
+    compile ":sonar-other-dep:5.5.5"
+}
+EOF
+}
+
+# --- Test: update by PLUGIN_NAME ---
+TMP=$(mktemp)
+make_fixture "$TMP"
+BUILD_GRADLE_FILE="$TMP" PLUGIN_NAME=java RELEASE_VERSION=1.2.3.4567 \
+  bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "plugin-name updates matching plugin" "$TMP" ':sonar-java-plugin:1.2.3.4567'
+assert_not_contains "plugin-name does not touch other plugins" "$TMP" ':sonar-python-plugin:1.2.3.4567'
+assert_not_contains "non-plugin line untouched" "$TMP" ':sonar-other-dep:1.2.3.4567'
+rm "$TMP"
+
+# --- Test: update by PLUGIN_ARTIFACTS (single) ---
+TMP=$(mktemp)
+make_fixture "$TMP"
+BUILD_GRADLE_FILE="$TMP" PLUGIN_NAME=ignored PLUGIN_ARTIFACTS=python RELEASE_VERSION=9.9.9.9999 \
+  bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "plugin-artifacts updates named artifact" "$TMP" ':sonar-python-plugin:9.9.9.9999'
+assert_not_contains "plugin-artifacts does not touch others" "$TMP" ':sonar-java-plugin:9.9.9.9999'
+rm "$TMP"
+
+# --- Test: update by PLUGIN_ARTIFACTS (comma-separated) ---
+TMP=$(mktemp)
+make_fixture "$TMP"
+BUILD_GRADLE_FILE="$TMP" PLUGIN_NAME=ignored PLUGIN_ARTIFACTS='java,python' RELEASE_VERSION=3.0.0.1 \
+  bash "$SCRIPT" >/dev/null 2>&1
+assert_contains "multi-artifact updates java" "$TMP" ':sonar-java-plugin:3.0.0.1'
+assert_contains "multi-artifact updates python" "$TMP" ':sonar-python-plugin:3.0.0.1'
+rm "$TMP"
+
+# --- Test: missing file fails ---
+if BUILD_GRADLE_FILE=/nonexistent/build.gradle PLUGIN_NAME=java RELEASE_VERSION=1.0 \
+    bash "$SCRIPT" >/dev/null 2>&1; then
+  echo "❌ missing file should fail"
+  FAIL=$((FAIL+1))
+else
+  echo "✅ missing file correctly fails"
+  PASS=$((PASS+1))
+fi
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[[ "$FAIL" -eq 0 ]]

--- a/update-analyzer/update_build_gradle.sh
+++ b/update-analyzer/update_build_gradle.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Updates analyzer plugin versions in a Gradle build file.
+#
+# Environment variables (required):
+#   BUILD_GRADLE_FILE - path to the Gradle build file to update
+#   RELEASE_VERSION   - new version string (e.g. 11.44.2.12345)
+#
+# Environment variables (optional):
+#   PLUGIN_ARTIFACTS  - comma-separated artifact names to update instead of PLUGIN_NAME
+#   PLUGIN_NAME       - plugin name used when PLUGIN_ARTIFACTS is empty; supports glob (e.g. java.*)
+
+set -euo pipefail
+
+BUILD_GRADLE_FILE="${BUILD_GRADLE_FILE:?BUILD_GRADLE_FILE is required}"
+RELEASE_VERSION="${RELEASE_VERSION:?RELEASE_VERSION is required}"
+PLUGIN_NAME="${PLUGIN_NAME:?PLUGIN_NAME is required}"
+PLUGIN_ARTIFACTS="${PLUGIN_ARTIFACTS:-}"
+
+if [[ ! -f "$BUILD_GRADLE_FILE" ]]; then
+  echo "::error::${BUILD_GRADLE_FILE} not found." >&2
+  exit 1
+fi
+
+declare -a plugins=()
+if [[ -n "$PLUGIN_ARTIFACTS" ]]; then
+  echo "Using plugin-artifacts: $PLUGIN_ARTIFACTS"
+  IFS=',' read -ra raw_plugins <<< "$PLUGIN_ARTIFACTS"
+  for raw in "${raw_plugins[@]}"; do
+    plugin="$(echo "$raw" | xargs)"
+    [[ -n "$plugin" ]] && plugins+=("$plugin")
+  done
+else
+  echo "Using plugin-name: $PLUGIN_NAME"
+  plugins=("${PLUGIN_NAME}.*")
+fi
+
+for plugin in "${plugins[@]}"; do
+  echo "Updating analyzer version in ${BUILD_GRADLE_FILE} for plugin ${plugin}"
+  # Use a temp file for cross-platform compatibility (macOS BSD sed vs GNU sed)
+  local_tmp=$(mktemp)
+  sed "s/\(:sonar-$plugin-plugin:\)[0-9.]*/\1$RELEASE_VERSION/g" "$BUILD_GRADLE_FILE" > "$local_tmp"
+  mv "$local_tmp" "$BUILD_GRADLE_FILE"
+done
+
+echo "Showing diff:"
+git --no-pager diff "$BUILD_GRADLE_FILE" 2>/dev/null || true

--- a/update-plugins-deployer/action.yml
+++ b/update-plugins-deployer/action.yml
@@ -38,13 +38,6 @@ outputs:
 runs:
   using: 'composite'
   steps:
-    - name: Get GitHub token from Vault
-      id: secrets
-      uses: SonarSource/vault-action-wrapper@v3
-      with:
-        secrets: |
-          development/github/token/SonarSource-${{ inputs.secret-name}} token | GITHUB_TOKEN;
-
     - name: Validate ticket and set commit prefix
       id: setup_env
       shell: bash
@@ -52,6 +45,7 @@ runs:
         TICKET_KEY: ${{ inputs.ticket-key }}
         DRAFT: ${{ inputs.draft }}
       run: |
+        set -euo pipefail
         if [[ "$TICKET_KEY" != SC-* ]]; then
           echo "::error::Invalid ticket format '${TICKET_KEY}'. Must start with SC-."
           exit 1
@@ -63,34 +57,22 @@ runs:
           echo "commit-prefix=$TICKET_KEY" >> $GITHUB_OUTPUT
         fi
 
-    - name: Checkout sonar-plugins-deployer
-      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      with:
-        repository: SonarSource/sonar-plugins-deployer
-        ref: ${{ inputs.base-branch }}
-        sparse-checkout: plugins.yaml
-        sparse-checkout-cone-mode: false
-        fetch-depth: 0
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-
-    - name: Update analyzer version in plugins.yaml
-      shell: bash
-      env:
-        PLUGINS_YAML: plugins.yaml
-        PLUGIN_NAME: ${{ inputs.plugin-name }}
-        RELEASE_VERSION: ${{ inputs.release-version }}
-      run: bash ${{ github.action_path }}/update_plugins_yaml.sh
-
-    - name: Create Pull Request
+    - name: Update version and create pull request
       id: create_pr
-      uses: SonarSource/release-github-actions/create-pull-request@v1
+      uses: SonarSource/release-github-actions/update-version-pr@v1
       with:
-        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
-        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        secret-name: ${{ inputs.secret-name }}
+        target-repo: SonarSource/sonar-plugins-deployer
+        sparse-paths: plugins.yaml
+        base-branch: ${{ inputs.base-branch }}
+        edit-script: ${{ github.action_path }}/update_plugins_yaml.sh
+        edit-env: |
+          PLUGINS_YAML=plugins.yaml
+          PLUGIN_NAME=${{ inputs.plugin-name }}
+          RELEASE_VERSION=${{ inputs.release-version }}
         commit-message: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` plugins to version ${{ inputs.release-version }}'
         title: '${{ steps.setup_env.outputs.commit-prefix }} Update `${{ inputs.plugin-name }}` to version ${{ inputs.release-version }}'
         body: ${{ inputs.pull-request-body }}
-        base: ${{ inputs.base-branch }}
         branch: '${{ inputs.plugin-name }}/update-analyzer-${{ inputs.release-version }}'
         draft: ${{ inputs.draft }}
         reviewers: ${{ inputs.reviewers }}

--- a/update-version-pr/README.md
+++ b/update-version-pr/README.md
@@ -1,0 +1,49 @@
+# Update Version PR
+
+Checks out a target repository (sparse), runs a caller-supplied edit script, and opens a pull request via [`create-pull-request`](../create-pull-request/README.md).
+
+This action owns the common wrapper shared by [`update-analyzer`](../update-analyzer/README.md), [`update-analysis-as-a-service`](../update-analysis-as-a-service/README.md), and [`update-plugins-deployer`](../update-plugins-deployer/README.md). Each of those actions holds its own edit script (the genuinely-different file-format logic) and calls this action for the git/PR plumbing.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `secret-name` | ✅ | | Vault secret name. Resolves to `development/github/token/SonarSource-<secret-name>`. |
+| `target-repo` | ✅ | | Repository to check out, e.g. `SonarSource/sonar-plugins-deployer`. |
+| `sparse-paths` | ✅ | | Sparse-checkout path(s) for the target file(s). |
+| `base-branch` | | `master` | Branch to check out and target for the PR. |
+| `edit-script` | ✅ | | Absolute path to the script that edits the checked-out file(s). Pass `${{ github.action_path }}/your-script.sh` from the calling action so the path resolves to the caller's directory. |
+| `edit-env` | | `''` | Newline-separated `KEY=VALUE` pairs exported into the environment before the edit script runs. |
+| `commit-message` | ✅ | | Commit message for the pull request. |
+| `title` | ✅ | | Pull request title. |
+| `body` | | `''` | Pull request body. |
+| `branch` | ✅ | | Branch name for the pull request. |
+| `draft` | | `false` | Open the pull request as a draft. |
+| `reviewers` | | `''` | Comma-separated list of GitHub usernames to request review from. |
+
+## Outputs
+
+| Output | Description |
+|--------|-------------|
+| `pull-request-url` | URL of the created or updated pull request. |
+
+## Usage
+
+```yaml
+- name: Update version and open PR
+  uses: SonarSource/release-github-actions/update-version-pr@v1
+  with:
+    secret-name: my-analyzer-release-automation
+    target-repo: SonarSource/my-target-repo
+    sparse-paths: path/to/version-file.toml
+    edit-script: ${{ github.action_path }}/update_version.sh
+    edit-env: |
+      TARGET_FILE=path/to/version-file.toml
+      PLUGIN_NAME=${{ inputs.plugin-name }}
+      RELEASE_VERSION=${{ inputs.release-version }}
+    commit-message: '[MY-123] Update my-plugin to ${{ inputs.release-version }}'
+    title: '[MY-123] Update my-plugin to ${{ inputs.release-version }}'
+    branch: my-plugin/update-${{ inputs.release-version }}
+    draft: ${{ inputs.draft }}
+    reviewers: ${{ inputs.reviewers }}
+```

--- a/update-version-pr/action.yml
+++ b/update-version-pr/action.yml
@@ -1,0 +1,99 @@
+name: 'Update Version PR'
+description: 'Checks out a target repository, runs a caller-supplied edit script, and opens a pull request.'
+author: 'SonarSource'
+
+inputs:
+  secret-name:
+    description: 'Name of the vault secret to fetch. Resolves to development/github/token/SonarSource-<secret-name>.'
+    required: true
+  target-repo:
+    description: 'The target repository to check out (e.g. SonarSource/sonar-plugins-deployer).'
+    required: true
+  sparse-paths:
+    description: 'Sparse-checkout path(s) for the target file(s).'
+    required: true
+  base-branch:
+    description: 'The base branch to check out and target for the pull request.'
+    required: false
+    default: 'master'
+  edit-script:
+    description: 'Absolute path to the script that edits the checked-out file(s). Typically ${{ github.action_path }}/script.sh from the caller.'
+    required: true
+  edit-env:
+    description: 'Newline-separated KEY=VALUE pairs exported into the environment before running the edit script.'
+    required: false
+    default: ''
+  commit-message:
+    description: 'The commit message for the pull request.'
+    required: true
+  title:
+    description: 'The title of the pull request.'
+    required: true
+  body:
+    description: 'The body of the pull request.'
+    required: false
+    default: ''
+  branch:
+    description: 'The branch name for the pull request.'
+    required: true
+  draft:
+    description: 'Create the pull request as a draft.'
+    required: false
+    default: 'false'
+  reviewers:
+    description: 'A comma-separated list of GitHub usernames to request a review from.'
+    required: false
+    default: ''
+
+outputs:
+  pull-request-url:
+    description: 'The URL of the created or updated pull request.'
+    value: ${{ steps.create-pr.outputs.pull-request-url }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Get GitHub token from Vault
+      id: secrets
+      uses: SonarSource/vault-action-wrapper@v3
+      with:
+        secrets: |
+          development/github/token/SonarSource-${{ inputs.secret-name }} token | GITHUB_TOKEN;
+
+    - name: Checkout target repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        repository: ${{ inputs.target-repo }}
+        ref: ${{ inputs.base-branch }}
+        sparse-checkout: ${{ inputs.sparse-paths }}
+        sparse-checkout-cone-mode: false
+        fetch-depth: 0
+        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+
+    - name: Run edit script
+      shell: bash
+      env:
+        EDIT_SCRIPT: ${{ inputs.edit-script }}
+        EDIT_ENV: ${{ inputs.edit-env }}
+      run: |
+        set -euo pipefail
+        # Export caller-supplied environment variables
+        while IFS= read -r line; do
+          [[ -z "$line" ]] && continue
+          export "$line"
+        done <<< "$EDIT_ENV"
+        bash "$EDIT_SCRIPT"
+
+    - name: Create Pull Request
+      id: create-pr
+      uses: SonarSource/release-github-actions/create-pull-request@v1
+      with:
+        token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
+        author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+        commit-message: ${{ inputs.commit-message }}
+        title: ${{ inputs.title }}
+        body: ${{ inputs.body }}
+        base: ${{ inputs.base-branch }}
+        branch: ${{ inputs.branch }}
+        draft: ${{ inputs.draft }}
+        reviewers: ${{ inputs.reviewers }}


### PR DESCRIPTION
## Summary

The three `update-*` actions (`update-analyzer`, `update-analysis-as-a-service`, `update-plugins-deployer`) all duplicated the same boilerplate shell: fetch vault token → sparse-checkout target repo → run edit script → call `create-pull-request`. This PR extracts that into a new `update-version-pr` action so each wrapper shrinks to just its genuinely-unique bits.

**What changed:**
- New `update-version-pr/` action: owns vault, checkout, edit-script execution, and PR creation. Edit logic (the actual file-format-specific scripts) stays per-target.
- `update-analyzer`: inline sed loop extracted to `update_build_gradle.sh` (+ test); `action.yml` trimmed to ticket→repo mapping step + call to `update-version-pr`.
- `update-analysis-as-a-service`, `update-plugins-deployer`: `action.yml` rewritten as thin wrappers.
- New `test-update-version-pr.yml`: schema validation (composite, inputs/outputs, pipefail, no-injection) + `update_build_gradle.sh` unit tests.

**What didn't change:**
- All three wrappers keep identical input/output signatures — no downstream breakage.
- The edit scripts (`update_libs_versions_toml.sh`, `update_plugins_yaml.sh`) are untouched.
- `sonar-update-center-release` and `bump-version` are out of scope (different shapes).

## Test plan

- [ ] Schema validation job in `test-update-version-pr.yml` passes
- [ ] `update_build_gradle.sh` unit tests pass (8 cases)
- [ ] `test-update-analyzer.yml` action tests still pass (ticket validation, existing script tests)
- [ ] `test-update-plugins-deployer.yml` action tests still pass
- [ ] `test-update-analysis-as-a-service.yml` action tests still pass

> **Note:** The three wrapper actions reference `update-version-pr@v1` which won't resolve until this is tagged. The wrapper action tests use `uses: ./update-*` (local path) which calls the local wrappers; those wrappers then call `@v1`. This is the same pattern as `create-pull-request` — the integration tests require the tag to be present, but schema and unit tests run fine on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)