### PR TITLE
GHA-345 Use SC ticket key as AaaS PR prefix instead of [AaaS]

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -896,11 +896,12 @@ jobs:
   update-analysis-as-a-service:
     name: Update Analyzer in Analysis as a Service
     runs-on: ${{ inputs.runner-environment }}
-    needs: [ prepare-release ]
+    needs: [ prepare-release, create-integration-tickets ]
     if: |
       inputs.sqc-integration && inputs.sqaa-integration &&
       !cancelled() &&
-      needs.prepare-release.result == 'success'
+      needs.prepare-release.result == 'success' &&
+      needs.create-integration-tickets.result == 'success'
     permissions:
       id-token: write
     outputs:
@@ -911,6 +912,7 @@ jobs:
         uses: SonarSource/release-github-actions/update-analysis-as-a-service@v1
         with:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
+          ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}
           plugin-name: ${{ inputs.plugin-name }}
           secret-name: ${{ inputs.release-automation-secret-name || format('sonar-{0}-release-automation', inputs.plugin-name) }}
           plugin-artifacts: ${{ inputs.plugin-artifacts-sqaa }}

--- a/update-analysis-as-a-service/README.md
+++ b/update-analysis-as-a-service/README.md
@@ -25,7 +25,7 @@ The `secret-name` provided to the action must have the following permissions on 
 | `plugin-name`       | The language key of the plugin to update. Used in the PR title and as the default version-key source.           | `true`   |          |
 | `secret-name`       | Name of the Vault secret for a GitHub token with access to `sonar-analysis-as-a-service`.                       | `true`   |          |
 | `plugin-artifacts`  | Comma-separated analyzer artifact names to update instead of `plugin-name`.                                     | `false`  |          |
-| `ticket-key`        | The Jira ticket key (e.g., `SC-12345`). Used as the PR title and commit message prefix.                         | `false`  |          |
+| `ticket-key`        | The Jira ticket key (e.g., `SC-12345`). Used as the PR title and commit message prefix.                         | `true`   |          |
 | `base-branch`       | The base branch for the pull request.                                                                          | `false`  | `master` |
 | `draft`             | Whether to create the pull request as a draft. When `true`, prefixes title and commit with `[DO NOT MERGE]`.   | `false`  | `false`  |
 | `reviewers`         | A comma-separated list of GitHub usernames to request a review from.                                            | `false`  |          |

--- a/update-analysis-as-a-service/README.md
+++ b/update-analysis-as-a-service/README.md
@@ -25,8 +25,9 @@ The `secret-name` provided to the action must have the following permissions on 
 | `plugin-name`       | The language key of the plugin to update. Used in the PR title and as the default version-key source.           | `true`   |          |
 | `secret-name`       | Name of the Vault secret for a GitHub token with access to `sonar-analysis-as-a-service`.                       | `true`   |          |
 | `plugin-artifacts`  | Comma-separated analyzer artifact names to update instead of `plugin-name`.                                     | `false`  |          |
+| `ticket-key`        | The Jira ticket key (e.g., `SC-12345`). Used as the PR title and commit message prefix.                         | `false`  |          |
 | `base-branch`       | The base branch for the pull request.                                                                          | `false`  | `master` |
-| `draft`             | Whether to create the pull request as a draft.                                                                  | `false`  | `false`  |
+| `draft`             | Whether to create the pull request as a draft. When `true`, prefixes title and commit with `[DO NOT MERGE]`.   | `false`  | `false`  |
 | `reviewers`         | A comma-separated list of GitHub usernames to request a review from.                                            | `false`  |          |
 | `pull-request-body` | The body of the pull request.                                                                                  | `false`  |          |
 

--- a/update-analysis-as-a-service/action.yml
+++ b/update-analysis-as-a-service/action.yml
@@ -19,8 +19,11 @@ inputs:
     description: 'The base branch for the pull request.'
     required: false
     default: 'master'
+  ticket-key:
+    description: 'The Jira ticket key (e.g., SC-12345). Used as the PR title and commit message prefix.'
+    required: false
   draft:
-    description: 'A boolean value to control if the pull request is created as a draft. When true, the commit message is prefixed with [DO NOT MERGE].'
+    description: 'A boolean value to control if the pull request is created as a draft. When true, the title and commit message are prefixed with [DO NOT MERGE].'
     required: false
     default: 'false'
   reviewers:
@@ -50,11 +53,12 @@ runs:
       shell: bash
       env:
         DRAFT: ${{ inputs.draft }}
+        TICKET_KEY: ${{ inputs.ticket-key }}
       run: |
         if [[ "$DRAFT" == "true" ]]; then
           echo "commit-prefix=[DO NOT MERGE]" >> "$GITHUB_OUTPUT"
         else
-          echo "commit-prefix=[AaaS]" >> "$GITHUB_OUTPUT"
+          echo "commit-prefix=$TICKET_KEY" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Checkout sonar-analysis-as-a-service

--- a/update-analysis-as-a-service/action.yml
+++ b/update-analysis-as-a-service/action.yml
@@ -21,7 +21,7 @@ inputs:
     default: 'master'
   ticket-key:
     description: 'The Jira ticket key (e.g., SC-12345). Used as the PR title and commit message prefix.'
-    required: false
+    required: true
   draft:
     description: 'A boolean value to control if the pull request is created as a draft. When true, the title and commit message are prefixed with [DO NOT MERGE].'
     required: false


### PR DESCRIPTION
## Summary
- Adds `ticket-key` input to `update-analysis-as-a-service` action, mirroring the pattern used by `update-analyzer`
- Uses the SC ticket key (e.g. `SC-12345`) as the PR title and commit message prefix instead of the hardcoded `[AaaS]`
- Updates `automated-release.yml` to depend on `create-integration-tickets` and pass `sqc-ticket-key` through

## Test plan
- [ ] Verify a release with `sqaa-integration: true` produces an AaaS PR titled `SC-XXXXX Update ...` matching the SQC integration PR ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)