### PR TITLE
GHA-347 Add release-lock gate to prevent non-bump PRs from merging mid-release

### DIFF
--- a/.claude/skills/automated-release-setup/SKILL.md
+++ b/.claude/skills/automated-release-setup/SKILL.md
@@ -512,7 +512,8 @@ is open, all other PRs get a red `release-lock` status; the bump PR itself gets 
 bump PR merges, all other open PRs automatically flip back to green — developers do not need to
 retrigger anything.
 
-Create `.github/workflows/release-lock${EXT}` (use the same extension detected in Step 1c):
+The logic lives in a reusable workflow in `release-github-actions`. Create a thin caller at
+`.github/workflows/release-lock${EXT}` (use the same extension detected in Step 1c):
 
 ```yaml
 name: Release lock
@@ -521,102 +522,23 @@ on:
   pull_request_target:
     types: [opened, reopened, synchronize, closed]
 
-permissions:
-  statuses: write
-  pull-requests: read
-
 jobs:
   release-lock:
-    name: Set release-lock status
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set release-lock status
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
-          PR_ACTION: ${{ github.event.action }}
-        run: |
-          BUMP_BRANCH_PREFIX="bot/prepare-next-development-iteration-"
-          CONTEXT="release-lock"
-
-          post_status() {
-            local sha="$1" state="$2" description="$3"
-            gh api --method POST \
-              "/repos/${GH_REPO}/statuses/${sha}" \
-              -f state="$state" \
-              -f context="$CONTEXT" \
-              -f description="$description"
-          }
-
-          if [[ "$PR_HEAD_BRANCH" == ${BUMP_BRANCH_PREFIX}* ]]; then
-            # This is the version-bump PR.
-            if [[ "$PR_ACTION" == "closed" ]]; then
-              # Bump PR merged/abandoned — reset all other open PRs to green.
-              echo "Bump PR closed. Resetting all open PRs to green..."
-              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
-                    --jq '.[] | "\(.number) \(.headRefOid)"')
-              while IFS=' ' read -r num sha; do
-                [ -z "$num" ] && continue
-                echo "  Resetting PR #$num (${sha:0:7}) to success"
-                post_status "$sha" "success" "No release in progress"
-              done <<< "$prs"
-            else
-              # Bump PR opened/updated — mark itself green, all others red.
-              echo "Bump PR opened/updated. Setting bump PR green, all others red..."
-              post_status "$PR_HEAD_SHA" "success" "Version-bump PR — may merge"
-              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
-                    --jq '.[] | "\(.number) \(.headRefOid)"')
-              while IFS=' ' read -r num sha; do
-                [ -z "$num" ] && continue
-                [ "$num" -eq "$PR_NUMBER" ] && continue  # skip bump PR itself
-                echo "  Blocking PR #$num (${sha:0:7})"
-                post_status "$sha" "failure" "Release in progress — merge the version-bump PR first"
-              done <<< "$prs"
-            fi
-          else
-            # Normal PR event — check if a bump PR is currently open.
-            bump_pr=$(gh pr list --state open --head "${BUMP_BRANCH_PREFIX}" \
-                      --json number --jq '.[0].number' 2>/dev/null || true)
-            if [ -n "$bump_pr" ] && [ "$bump_pr" != "null" ]; then
-              echo "Bump PR #$bump_pr is open. Blocking this PR."
-              post_status "$PR_HEAD_SHA" "failure" \
-                "Release in progress — merge the version-bump PR (#${bump_pr}) first"
-            else
-              echo "No bump PR open. Setting this PR to success."
-              post_status "$PR_HEAD_SHA" "success" "No release in progress"
-            fi
-          fi
+    uses: SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1
+    permissions:
+      statuses: write
+      pull-requests: read
 ```
 
-> **Note on `--head` filtering:** The `gh pr list --head` flag matches on the exact head branch
-> name, not a prefix. The `bump_pr=$(gh pr list --state open --head "${BUMP_BRANCH_PREFIX}"…)`
-> call above will only find a bump PR if the branch name is exactly the prefix (unlikely). For
-> the normal-PR path, this is fine — `gh pr list` with the bump-PR detection loop would be
-> needed for strict prefix matching. A simpler equivalent that works for a single bump PR:
-> ```bash
-> bump_pr=$(gh pr list --state open --json number,headRefName \
->   --jq '.[] | select(.headRefName | startswith("'"${BUMP_BRANCH_PREFIX}"'")) | .number' \
->   | head -1)
-> ```
-> Use this `jq`-based approach instead of `--head` for the normal-PR branch of the script.
-
-**Corrected normal-PR branch (replace the `bump_pr=` line above with):**
-```bash
-bump_pr=$(gh pr list --state open --json number,headRefName --limit 200 \
-  --jq '.[] | select(.headRefName | startswith("'"${BUMP_BRANCH_PREFIX}"'")) | .number' \
-  | head -1)
-```
+That's the entire file — all logic is in the reusable workflow and updates automatically with
+`@v1`.
 
 Stage and commit alongside the `automated-release${EXT}` file:
 ```bash
 git add .github/workflows/release-lock${EXT}
 ```
 
-**Important:** `pull_request_target` runs with the base branch's code, so the workflow above
+**Important:** `pull_request_target` runs with the base branch's code, so the caller above
 is safe — it does **not** check out any untrusted PR code. Never add a `checkout` step to this
 workflow unless you understand the security implications of `pull_request_target`.
 

--- a/.claude/skills/automated-release-setup/SKILL.md
+++ b/.claude/skills/automated-release-setup/SKILL.md
@@ -501,6 +501,187 @@ Create a PR in the `re-terraform-aws-vault` repository to add the release-automa
    - [ ] Test automated release workflow with dry-run"
    ```
 
+### Step 5c: Add `release-lock.yml` (Phase 1 — unenforced status check)
+
+This step adds the `release-lock` commit status workflow to the repo. While the check is not yet
+required, it reports a green/red status on every PR so the team can observe correct behavior over
+one or two releases before enforcing it (Phase 2).
+
+**What it does:** When a version-bump PR (head branch `bot/prepare-next-development-iteration-*`)
+is open, all other PRs get a red `release-lock` status; the bump PR itself gets green. When the
+bump PR merges, all other open PRs automatically flip back to green — developers do not need to
+retrigger anything.
+
+Create `.github/workflows/release-lock${EXT}` (use the same extension detected in Step 1c):
+
+```yaml
+name: Release lock
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, closed]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+jobs:
+  release-lock:
+    name: Set release-lock status
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set release-lock status
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_ACTION: ${{ github.event.action }}
+        run: |
+          BUMP_BRANCH_PREFIX="bot/prepare-next-development-iteration-"
+          CONTEXT="release-lock"
+
+          post_status() {
+            local sha="$1" state="$2" description="$3"
+            gh api --method POST \
+              "/repos/${GH_REPO}/statuses/${sha}" \
+              -f state="$state" \
+              -f context="$CONTEXT" \
+              -f description="$description"
+          }
+
+          if [[ "$PR_HEAD_BRANCH" == ${BUMP_BRANCH_PREFIX}* ]]; then
+            # This is the version-bump PR.
+            if [[ "$PR_ACTION" == "closed" ]]; then
+              # Bump PR merged/abandoned — reset all other open PRs to green.
+              echo "Bump PR closed. Resetting all open PRs to green..."
+              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
+                    --jq '.[] | "\(.number) \(.headRefOid)"')
+              while IFS=' ' read -r num sha; do
+                [ -z "$num" ] && continue
+                echo "  Resetting PR #$num (${sha:0:7}) to success"
+                post_status "$sha" "success" "No release in progress"
+              done <<< "$prs"
+            else
+              # Bump PR opened/updated — mark itself green, all others red.
+              echo "Bump PR opened/updated. Setting bump PR green, all others red..."
+              post_status "$PR_HEAD_SHA" "success" "Version-bump PR — may merge"
+              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
+                    --jq '.[] | "\(.number) \(.headRefOid)"')
+              while IFS=' ' read -r num sha; do
+                [ -z "$num" ] && continue
+                [ "$num" -eq "$PR_NUMBER" ] && continue  # skip bump PR itself
+                echo "  Blocking PR #$num (${sha:0:7})"
+                post_status "$sha" "failure" "Release in progress — merge the version-bump PR first"
+              done <<< "$prs"
+            fi
+          else
+            # Normal PR event — check if a bump PR is currently open.
+            bump_pr=$(gh pr list --state open --head "${BUMP_BRANCH_PREFIX}" \
+                      --json number --jq '.[0].number' 2>/dev/null || true)
+            if [ -n "$bump_pr" ] && [ "$bump_pr" != "null" ]; then
+              echo "Bump PR #$bump_pr is open. Blocking this PR."
+              post_status "$PR_HEAD_SHA" "failure" \
+                "Release in progress — merge the version-bump PR (#${bump_pr}) first"
+            else
+              echo "No bump PR open. Setting this PR to success."
+              post_status "$PR_HEAD_SHA" "success" "No release in progress"
+            fi
+          fi
+```
+
+> **Note on `--head` filtering:** The `gh pr list --head` flag matches on the exact head branch
+> name, not a prefix. The `bump_pr=$(gh pr list --state open --head "${BUMP_BRANCH_PREFIX}"…)`
+> call above will only find a bump PR if the branch name is exactly the prefix (unlikely). For
+> the normal-PR path, this is fine — `gh pr list` with the bump-PR detection loop would be
+> needed for strict prefix matching. A simpler equivalent that works for a single bump PR:
+> ```bash
+> bump_pr=$(gh pr list --state open --json number,headRefName \
+>   --jq '.[] | select(.headRefName | startswith("'"${BUMP_BRANCH_PREFIX}"'")) | .number' \
+>   | head -1)
+> ```
+> Use this `jq`-based approach instead of `--head` for the normal-PR branch of the script.
+
+**Corrected normal-PR branch (replace the `bump_pr=` line above with):**
+```bash
+bump_pr=$(gh pr list --state open --json number,headRefName --limit 200 \
+  --jq '.[] | select(.headRefName | startswith("'"${BUMP_BRANCH_PREFIX}"'")) | .number' \
+  | head -1)
+```
+
+Stage and commit alongside the `automated-release${EXT}` file:
+```bash
+git add .github/workflows/release-lock${EXT}
+```
+
+**Important:** `pull_request_target` runs with the base branch's code, so the workflow above
+is safe — it does **not** check out any untrusted PR code. Never add a `checkout` step to this
+workflow unless you understand the security implications of `pull_request_target`.
+
+---
+
+### Step 5d: Register `release-lock` as a required check (Phase 2 — gated, do separately)
+
+> ⚠️ **Do not perform this step in the same skill run as Step 5c.** Only run Phase 2 when the
+> team has observed Phase 1 behaving correctly over one or two real releases. Registering a
+> required check without a working reporter blocks **all** PRs.
+
+When the team is confident, register `release-lock` as a required status check on the branch.
+This enforces the gate: while a bump PR is open, all other PRs are blocked from merging.
+
+**Prerequisite:** The `-lock` admin Vault token must be available. Its path is
+`development/github/token/{REPO_OWNER_NAME_DASH}-lock` (e.g., `sonar-apex` →
+`development/github/token/sonar-apex-lock`). This token already has admin branch-protection
+write (used by the freeze/unfreeze jobs). Confirm the secret is available before running.
+
+**Step 5d-1:** Get the current branch protection settings to preserve all existing contexts:
+```bash
+CURRENT=$(gh api "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --jq '.required_status_checks.contexts // []')
+echo "Current contexts: $CURRENT"
+```
+
+**Step 5d-2:** Add `release-lock` to the contexts list and update protection. Use the
+[`lock-branch` action](../lock-branch/) in a one-shot job or run the Vault-authenticated API
+call directly (the lock-branch action preserves contexts at `lock_branch.py:105-112` — you can
+also run it as `freeze: false` to trigger a no-op unfreeze that re-writes the protection and
+preserves contexts).
+
+The safest approach is to use the GitHub UI:
+1. Go to **Settings → Branches → Branch protection rules** → edit the rule for `master` (or
+   the release branch).
+2. Under **Require status checks to pass before merging**, search for and add `release-lock`.
+3. Save.
+
+Or via the API (requires admin token):
+```bash
+# Get current contexts
+contexts=$(gh api "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --jq '[.required_status_checks.contexts[]]')
+
+# Append release-lock and update (one-liner — adjust if contexts is already an array)
+gh api --method PUT "/repos/${REPO}/branches/${BRANCH}/protection" \
+  --input - <<EOF
+{
+  "required_status_checks": {
+    "strict": false,
+    "contexts": $(echo "$contexts" | jq '. + ["release-lock"]')
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+```
+
+> **Freeze coexistence:** Once `release-lock` is registered, it survives freeze/unfreeze cycles
+> — `lock_branch.py` (`lock_branch.py:105-112`) preserves `required_status_checks.contexts`
+> on every PUT, so the context is never dropped.
+
+---
+
 ### Step 6: Testing Instructions
 
 Provide these instructions to the user:

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -253,10 +253,39 @@ env:
   USE_JIRA_SANDBOX: ${{ inputs.use-jira-sandbox == true && 'true' || 'false' }}
 
 jobs:
+  # Strip auto-merge from every open PR before the release touches anything.
+  # Prevents the race where a pre-approved PR with auto-merge enabled and CI still running
+  # could merge mid-release before the version-bump PR is created.
+  # This runs unconditionally and independently of freeze-branch.
+  disable-auto-merge:
+    name: Disable auto-merge on open PRs
+    runs-on: ${{ inputs.runner-environment }}
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Disable auto-merge on all open PRs
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_numbers=$(gh pr list --state open --json number --jq '.[].number')
+          if [ -z "$pr_numbers" ]; then
+            echo "No open PRs found."
+            exit 0
+          fi
+          for pr in $pr_numbers; do
+            echo "Disabling auto-merge on PR #$pr (no-op if not enabled)"
+            gh pr merge "$pr" --disable-auto-merge 2>/dev/null \
+              || echo "  (PR #$pr: auto-merge already disabled or PR is not mergeable)"
+          done
+          echo "Auto-merge sweep complete."
+
   # This job freezes the specified branch to prevent changes during the release process.
   freeze-branch:
     name: Freeze ${{ inputs.branch }} branch
     if: ${{ inputs.freeze-branch }}
+    needs: [ disable-auto-merge ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write
@@ -288,7 +317,7 @@ jobs:
       inputs.check-releasability &&
       !cancelled() &&
       (needs.freeze-branch.result == 'success' || needs.freeze-branch.result == 'skipped')
-    needs: [ freeze-branch ]
+    needs: [ disable-auto-merge, freeze-branch ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -254,30 +254,31 @@ env:
 
 jobs:
   # Strip auto-merge from every open PR before the release touches anything.
-  # Prevents the race where a pre-approved PR with auto-merge enabled and CI still running
-  # could merge mid-release before the version-bump PR is created.
-  # This runs unconditionally and independently of freeze-branch.
+  # Only runs when bump-version is true: the auto-merge race only exists when a version-bump PR
+  # will be created. A pre-approved PR with auto-merge + pending CI could merge mid-release
+  # before the bump PR opens; stripping auto-merge up front closes that window.
   disable-auto-merge:
     name: Disable auto-merge on open PRs
+    if: ${{ inputs.bump-version }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       pull-requests: write
     steps:
-      - name: Disable auto-merge on all open PRs
+      - name: Disable auto-merge on open PRs with auto-merge enabled
         shell: bash
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_numbers=$(gh pr list --state open --json number --jq '.[].number')
+          pr_numbers=$(gh pr list --state open --json number,autoMergeRequest \
+            --jq '.[] | select(.autoMergeRequest != null) | .number')
           if [ -z "$pr_numbers" ]; then
-            echo "No open PRs found."
+            echo "No open PRs with auto-merge enabled."
             exit 0
           fi
           for pr in $pr_numbers; do
-            echo "Disabling auto-merge on PR #$pr (no-op if not enabled)"
-            gh pr merge "$pr" --disable-auto-merge 2>/dev/null \
-              || echo "  (PR #$pr: auto-merge already disabled or PR is not mergeable)"
+            echo "Disabling auto-merge on PR #$pr"
+            gh pr merge "$pr" --disable-auto-merge
           done
           echo "Auto-merge sweep complete."
 

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -286,7 +286,6 @@ jobs:
   freeze-branch:
     name: Freeze ${{ inputs.branch }} branch
     if: ${{ inputs.freeze-branch }}
-    needs: [ disable-auto-merge ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write
@@ -318,7 +317,7 @@ jobs:
       inputs.check-releasability &&
       !cancelled() &&
       (needs.freeze-branch.result == 'success' || needs.freeze-branch.result == 'skipped')
-    needs: [ disable-auto-merge, freeze-branch ]
+    needs: [ freeze-branch ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write

--- a/.github/workflows/release-lock.yml
+++ b/.github/workflows/release-lock.yml
@@ -1,0 +1,80 @@
+name: Release lock
+
+on:
+  workflow_call:
+    inputs:
+      bump-branch-prefix:
+        description: "Head branch prefix that identifies version-bump PRs"
+        required: false
+        type: string
+        default: "bot/prepare-next-development-iteration-"
+
+jobs:
+  release-lock:
+    name: Set release-lock status
+    runs-on: ubuntu-latest
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - name: Set release-lock status
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_ACTION: ${{ github.event.action }}
+          BUMP_BRANCH_PREFIX: ${{ inputs.bump-branch-prefix }}
+        run: |
+          CONTEXT="release-lock"
+
+          post_status() {
+            local sha="$1" state="$2" description="$3"
+            gh api --method POST \
+              "/repos/${GH_REPO}/statuses/${sha}" \
+              -f state="$state" \
+              -f context="$CONTEXT" \
+              -f description="$description"
+          }
+
+          if [[ "$PR_HEAD_BRANCH" == ${BUMP_BRANCH_PREFIX}* ]]; then
+            # This is the version-bump PR.
+            if [[ "$PR_ACTION" == "closed" ]]; then
+              # Bump PR merged/abandoned — reset all other open PRs to green.
+              echo "Bump PR closed. Resetting all open PRs to green..."
+              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
+                    --jq '.[] | "\(.number) \(.headRefOid)"')
+              while IFS=' ' read -r num sha; do
+                [ -z "$num" ] && continue
+                echo "  Resetting PR #$num (${sha:0:7}) to success"
+                post_status "$sha" "success" "No release in progress"
+              done <<< "$prs"
+            else
+              # Bump PR opened/updated — mark itself green, all others red.
+              echo "Bump PR opened/updated. Setting bump PR green, all others red..."
+              post_status "$PR_HEAD_SHA" "success" "Version-bump PR — may merge"
+              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
+                    --jq '.[] | "\(.number) \(.headRefOid)"')
+              while IFS=' ' read -r num sha; do
+                [ -z "$num" ] && continue
+                [ "$num" -eq "$PR_NUMBER" ] && continue  # skip bump PR itself
+                echo "  Blocking PR #$num (${sha:0:7})"
+                post_status "$sha" "failure" "Release in progress — merge the version-bump PR first"
+              done <<< "$prs"
+            fi
+          else
+            # Normal PR event — check if a bump PR is currently open.
+            bump_pr=$(gh pr list --state open --json number,headRefName --limit 200 \
+              --jq '.[] | select(.headRefName | startswith("'"${BUMP_BRANCH_PREFIX}"'")) | .number' \
+              | head -1)
+            if [ -n "$bump_pr" ] && [ "$bump_pr" != "null" ]; then
+              echo "Bump PR #$bump_pr is open. Blocking this PR."
+              post_status "$PR_HEAD_SHA" "failure" \
+                "Release in progress — merge the version-bump PR (#${bump_pr}) first"
+            else
+              echo "No bump PR open. Setting this PR to success."
+              post_status "$PR_HEAD_SHA" "success" "No release in progress"
+            fi
+          fi

--- a/README.md
+++ b/README.md
@@ -62,14 +62,17 @@ unfrozen branch.
 
 ### The solution
 
-A per-repo workflow (`release-lock.yml`) sets a `release-lock` commit status on every open PR.
+A thin caller workflow (`release-lock.yml`) in each analyzer repo delegates to the reusable
+`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`, which sets a
+`release-lock` commit status on every open PR.
 When a version-bump PR (head branch `bot/prepare-next-development-iteration-*`) is open:
 
 - **Version-bump PR** → ✅ `success` (can merge)
 - **Every other PR** → ❌ `failure` — "Release in progress — merge the version-bump PR first"
 
-When the bump PR merges, `release-lock.yml` sweeps all open PRs (paginated, including drafts)
+When the bump PR merges, the reusable workflow sweeps all open PRs (paginated, including drafts)
 and resets each to ✅ green **automatically** — developers do not need to push or retrigger.
+Logic updates propagate to all repos on the next `@v1` resolve.
 
 At release start, the workflow also strips **auto-merge** from all open PRs to close the race
 where a pre-approved PR with pending CI would auto-merge before the bump PR opens.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,78 @@
 
 A centralized collection of reusable GitHub Actions designed to streamline and automate every stage of the analyzer release process. This repository serves as a versatile toolbox, offering modular automations to eliminate manual, repetitive steps and reduce friction across squads managing analyzer projects. Whether standardizing changelog generation, automating version bumps, handling release publishing, or coordinating cross-repository tasks, these actions help teams back away from cumbersome workflows and focus more on code quality. Pick and combine the automations best suited for your analyzer’s unique release requirements, and easily extend the toolbox to cover new scenarios as they arise.
 
+## Automated Release Workflow
+
+> Analyzer release path (`automated-release.yml`). The DevEx/IDE path (`ide-automated-release.yml`) is separate.
+
+The automated release workflow orchestrates the full end-to-end release process. It is triggered
+manually via `workflow_dispatch` from the analyzer repo.
+
+### What happens when you trigger a release
+
+```
+┌─ release triggered ──────────────────────────────────────────────────────────┐
+│                                                                               │
+│  disable-auto-merge ──────────────────────────────────────────────────────►  │
+│  (strips auto-merge from all open PRs with it enabled, if bump-version: true)│
+│                                                                               │
+│  freeze-branch ────────────────────────────────────────────────────────────► │
+│  (locks the branch — optional, via freeze-branch input)                       │
+│                         │                                                     │
+│                         ▼                                                     │
+│               check-releasability                                             │
+│               (verifies the branch is releasable)                             │
+│                         │                                                     │
+│                         ▼                                                     │
+│               prepare-release                                                 │
+│               (resolves version, fetches Jira release notes)                  │
+│                         │                                                     │
+│           ┌─────────────┴──────────────────────┐                             │
+│           ▼                                     ▼                             │
+│  create-release-ticket              publish-github-release                    │
+│  (creates REL ticket in Jira)       (publishes the GitHub release)            │
+│           │                                     │                             │
+│           └────────────┬────────────────────────┘                             │
+│                        ▼                                                      │
+│               UNFREEZE branch                                                 │
+│                        │                                                      │
+│                        ▼                                                      │
+│               release-in-jira                                                 │
+│               (releases Jira version, creates next version)                   │
+│                        │                                                      │
+│           ┌────────────┴──────────────────┐                                  │
+│           ▼                               ▼                                   │
+│  bump-version                   create-integration-tickets                    │
+│  (opens version-bump PR)        (SLVS / SLE / SLI / SQS / SQC / ...)        │
+│           │                               │                                   │
+│           │                               ▼                                   │
+│           │                     update-analyzer PRs                           │
+│           │                     (PRs in sonar-enterprise, sonarcloud-core)    │
+│           ▼                                                                   │
+│  ◀── release DRI merges the version-bump PR ──────────────────────────────── │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### The release lock gate
+
+While the version-bump PR is open, a `release-lock` required status check prevents any other PR
+from merging into the branch:
+
+| PR | `release-lock` status |
+|---|---|
+| Version-bump PR | ✅ `success` — may merge |
+| Every other open PR | ❌ `failure` — "Release in progress — merge the version-bump PR first" |
+
+When the DRI merges the version-bump PR, all other open PRs automatically flip back to ✅ green
+— developers do not need to push or retrigger anything.
+
+The gate is implemented as a thin `release-lock.yml` caller in the analyzer repo that delegates
+to the reusable `SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`.
+Logic updates propagate to all repos on the next `@v1` resolve.
+
+See [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md) for full input reference, adoption
+steps, and the freeze-coexistence guarantee.
+
 ## Available Actions
 
 | Action                                                                  | Description |
@@ -28,38 +100,6 @@ A centralized collection of reusable GitHub Actions designed to streamline and a
 | [Update Plugins Deployer](update-plugins-deployer/README.md)            | Updates a plugin version in sonar-plugins-deployer and creates a pull request |
 | [Update Release Ticket Status](update-release-ticket-status/README.md)  | Updates the status of a Jira release ticket and can change its assignee |
 | [Update Rule Metadata](update-rule-metadata/README.md)                  | Automates updating rule metadata across all supported languages using the rule-api tooling |
-
-## Available Workflows
-
-| Workflow | Description |
-|----------|-------------|
-| [Automated Release Workflow](docs/AUTOMATED_RELEASE.md) | Orchestrates the end-to-end release across Jira and GitHub, with optional integration tickets and analyzer PRs |
-
-## Release lock gate
-
-> Analyzer release path (`automated-release.yml`) only. `ide-automated-release.yml` is not covered here.
-
-When a release is triggered, `automated-release.yml` strips auto-merge from all open PRs and
-(optionally) freezes the branch. After publishing the GitHub release the branch unfreezes, and
-the workflow creates a version-bump PR (`bot/prepare-next-development-iteration-*`).
-
-From that point, `release-lock` — a required status check backed by a thin `release-lock.yml`
-caller in the analyzer repo — gates what can merge:
-
-| PR | `release-lock` status |
-|---|---|
-| Version-bump PR | ✅ `success` — may merge |
-| Every other open PR | ❌ `failure` — "Release in progress — merge the version-bump PR first" |
-
-The release DRI merges the version-bump PR. On merge, `release-lock.yml` automatically resets
-all remaining open PRs to ✅ green — developers do not need to push or retrigger anything.
-
-The gate logic lives in the reusable
-`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`; analyzer repos
-hold only a 5-line caller. Updates propagate automatically on the next `@v1` resolve.
-
-See [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md#release-lock-gate) for adoption
-steps and the freeze-coexistence guarantee.
 
 ## Claude Code Skills
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,60 @@ A centralized collection of reusable GitHub Actions designed to streamline and a
 |----------|-------------|
 | [Automated Release Workflow](docs/AUTOMATED_RELEASE.md) | Orchestrates the end-to-end release across Jira and GitHub, with optional integration tickets and analyzer PRs |
 
+## Release lock gate
+
+> This section covers the **analyzer release path** (`automated-release.yml`). The DevEx/IDE
+> path (`ide-automated-release.yml`) is separate and not covered here.
+
+### The problem
+
+`automated-release.yml` freezes the branch at the start of the release to prevent unintended
+merges. But the freeze ends **before** the version-bump PR is created:
+
+```
+disable-auto-merge → freeze → check → prepare → publish-github-release
+                                                       ↓
+                            UNFREEZE ─────────────────┘
+                               ↓
+                       release-in-jira → bump-version (creates version-bump PR)
+```
+
+Between the unfreeze and the bump PR being merged, the branch is open. Other PRs can merge
+into that gap, leaving the branch at the released version with unbumped build files.
+
+The freeze (`lock_branch: true`) cannot extend past the unfreeze — it is all-or-nothing
+read-only for everyone, including the release DRI, and the bump PR push itself needs an
+unfrozen branch.
+
+### The solution
+
+A per-repo workflow (`release-lock.yml`) sets a `release-lock` commit status on every open PR.
+When a version-bump PR (head branch `bot/prepare-next-development-iteration-*`) is open:
+
+- **Version-bump PR** → ✅ `success` (can merge)
+- **Every other PR** → ❌ `failure` — "Release in progress — merge the version-bump PR first"
+
+When the bump PR merges, `release-lock.yml` sweeps all open PRs (paginated, including drafts)
+and resets each to ✅ green **automatically** — developers do not need to push or retrigger.
+
+At release start, the workflow also strips **auto-merge** from all open PRs to close the race
+where a pre-approved PR with pending CI would auto-merge before the bump PR opens.
+
+### Adoption (two phases, per repo, non-breaking)
+
+**Phase 1 — Add the workflow (unenforced).** Run the `automated-release-setup` skill (Step 5c)
+in your analyzer repo. It adds `release-lock.yml`. The check reports statuses but is not a
+required check, so it gates nothing. Observe over a release or two.
+
+**Phase 2 — Enforce.** When confident, run Step 5d of the skill. It registers `release-lock`
+as a required status check. Now only the bump PR can merge while a release is in progress.
+
+Repos that never run the skill release exactly as before — the only universal change is the
+auto-merge sweep at release start.
+
+See [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md#release-lock-gate) for the full
+rollout plan, the freeze-coexistence guarantee, and the migration guide.
+
 ## Claude Code Skills
 
 This repository includes Claude Code skills for automating common tasks related to release workflows. Skills are instruction files (`.claude/skills/<skill-name>/SKILL.md`) that teach Claude Code how to perform specific tasks, using YAML frontmatter for metadata followed by detailed instructions.

--- a/README.md
+++ b/README.md
@@ -37,60 +37,29 @@ A centralized collection of reusable GitHub Actions designed to streamline and a
 
 ## Release lock gate
 
-> This section covers the **analyzer release path** (`automated-release.yml`). The DevEx/IDE
-> path (`ide-automated-release.yml`) is separate and not covered here.
+> Analyzer release path (`automated-release.yml`) only. `ide-automated-release.yml` is not covered here.
 
-### The problem
+When a release is triggered, `automated-release.yml` strips auto-merge from all open PRs and
+(optionally) freezes the branch. After publishing the GitHub release the branch unfreezes, and
+the workflow creates a version-bump PR (`bot/prepare-next-development-iteration-*`).
 
-`automated-release.yml` freezes the branch at the start of the release to prevent unintended
-merges. But the freeze ends **before** the version-bump PR is created:
+From that point, `release-lock` — a required status check backed by a thin `release-lock.yml`
+caller in the analyzer repo — gates what can merge:
 
-```
-disable-auto-merge → freeze → check → prepare → publish-github-release
-                                                       ↓
-                            UNFREEZE ─────────────────┘
-                               ↓
-                       release-in-jira → bump-version (creates version-bump PR)
-```
+| PR | `release-lock` status |
+|---|---|
+| Version-bump PR | ✅ `success` — may merge |
+| Every other open PR | ❌ `failure` — "Release in progress — merge the version-bump PR first" |
 
-Between the unfreeze and the bump PR being merged, the branch is open. Other PRs can merge
-into that gap, leaving the branch at the released version with unbumped build files.
+The release DRI merges the version-bump PR. On merge, `release-lock.yml` automatically resets
+all remaining open PRs to ✅ green — developers do not need to push or retrigger anything.
 
-The freeze (`lock_branch: true`) cannot extend past the unfreeze — it is all-or-nothing
-read-only for everyone, including the release DRI, and the bump PR push itself needs an
-unfrozen branch.
+The gate logic lives in the reusable
+`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`; analyzer repos
+hold only a 5-line caller. Updates propagate automatically on the next `@v1` resolve.
 
-### The solution
-
-A thin caller workflow (`release-lock.yml`) in each analyzer repo delegates to the reusable
-`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`, which sets a
-`release-lock` commit status on every open PR.
-When a version-bump PR (head branch `bot/prepare-next-development-iteration-*`) is open:
-
-- **Version-bump PR** → ✅ `success` (can merge)
-- **Every other PR** → ❌ `failure` — "Release in progress — merge the version-bump PR first"
-
-When the bump PR merges, the reusable workflow sweeps all open PRs (paginated, including drafts)
-and resets each to ✅ green **automatically** — developers do not need to push or retrigger.
-Logic updates propagate to all repos on the next `@v1` resolve.
-
-At release start, the workflow also strips **auto-merge** from all open PRs to close the race
-where a pre-approved PR with pending CI would auto-merge before the bump PR opens.
-
-### Adoption (two phases, per repo, non-breaking)
-
-**Phase 1 — Add the workflow (unenforced).** Run the `automated-release-setup` skill (Step 5c)
-in your analyzer repo. It adds `release-lock.yml`. The check reports statuses but is not a
-required check, so it gates nothing. Observe over a release or two.
-
-**Phase 2 — Enforce.** When confident, run Step 5d of the skill. It registers `release-lock`
-as a required status check. Now only the bump PR can merge while a release is in progress.
-
-Repos that never run the skill release exactly as before — the only universal change is the
-auto-merge sweep at release start.
-
-See [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md#release-lock-gate) for the full
-rollout plan, the freeze-coexistence guarantee, and the migration guide.
+See [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md#release-lock-gate) for adoption
+steps and the freeze-coexistence guarantee.
 
 ## Claude Code Skills
 

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -145,13 +145,107 @@ jobs:
 - When `freeze-branch: true`, the workflow will:
   - Lock the specified branch at the start of the release
   - Proceed with the release steps
-  - Unlock the branch after the GitHub release is published
+  - Unlock the branch after the GitHub release is published — **before** the version-bump PR is created
   - Send lock/unlock notifications to the configured `slack-channel` if provided
+  - **Note:** The freeze window ends before the version-bump PR is created (see [Release lock gate](#release-lock-gate) below for how to protect that window).
+- **Auto-merge sweep (always runs):** At the very start of every release, the workflow strips
+  auto-merge from all open PRs. This prevents the race where a pre-approved PR with auto-merge
+  enabled and CI still running would otherwise merge mid-release before the version-bump PR is
+  created. PR owners can re-enable auto-merge after the release. This is best-effort — a PR
+  that re-enables auto-merge and completes CI in the brief window before the version-bump PR
+  opens may still slip through; the release-lock gate (see below) guards against this.
 - When `release-notes` is empty, Jira release notes are fetched and used.
 - Integration tickets and analyzer update PRs are created only if their respective flags are enabled and prerequisites are met.
 - Summaries:
   - Each job includes a "Summary" step that writes to `$GITHUB_STEP_SUMMARY` only when `verbose: true`.
 - Permissions and environments are scoped per job to minimize required privileges.
+
+## Release lock gate
+
+> **Scope:** Analyzer release path (`automated-release.yml`) only. The DevEx/IDE path
+> (`ide-automated-release.yml`) is separate and not covered here.
+
+### The problem
+
+The release workflow unfreezes the branch right after publishing the GitHub release, **before**
+the version-bump PR is created. The actual job ordering is:
+
+```
+disable-auto-merge → freeze → check → prepare → publish-github-release
+                                                        ↓
+                             UNFREEZE ←─────────────────┘
+                                ↓
+                        release-in-jira → bump-version (creates version-bump PR)
+```
+
+Between the unfreeze and the bump PR being created (and merged), the branch is open. Other
+developers' PRs can merge into that gap, leaving the branch at the released version with
+unbumped pom/gradle files.
+
+`lock_branch: true` (the freeze) cannot be extended to cover this window — it is all-or-nothing
+read-only for everyone including the release DRI, and the bump PR push itself requires an
+unfrozen branch.
+
+### The solution: `release-lock` required status check
+
+The "release in progress" signal is **"a version-bump PR is open."** A per-repo workflow
+(`release-lock.yml`) sets a `release-lock` commit status on every open PR:
+
+| Condition | Status on other PRs | Status on bump PR |
+|---|---|---|
+| No bump PR open | ✅ `success` — "No release in progress" | — |
+| Bump PR open | ❌ `failure` — "Release in progress — merge the version-bump PR first" | ✅ `success` |
+| Bump PR merged/abandoned | ✅ `success` (auto-reset, no retrigger needed) | — |
+
+The version-bump PR is identified by its head branch prefix
+`bot/prepare-next-development-iteration-` (invariant across Maven/Gradle/custom paths).
+
+When the bump PR closes, `release-lock.yml` sweeps all open PRs (paginated, drafts included)
+and resets each to green **automatically** — developers do not need to push or retrigger.
+
+### Adopt the gate (two-phase, per repo, via the setup skill)
+
+> The gate is **opt-in** and non-breaking. A repo with no `release-lock.yml` and no required
+> check releases exactly as before — the only change for all callers is the auto-merge sweep at
+> release start.
+
+#### Phase 1 — Add the workflow (unenforced)
+
+Run the `automated-release-setup` skill (Step 5c). It creates `release-lock.yml` in your repo.
+The check reports green/red on PRs but is **not required**, so it gates nothing. Observe over
+one or two real releases that the statuses behave correctly (other PRs go red while a bump PR
+is open; all reset to green when it merges).
+
+#### Phase 2 — Enforce (when ready)
+
+Run Step 5d of the skill (deliberately separate from Step 5c). It registers `release-lock` as
+a **required** status check on the branch. After this: while a bump PR is open, only that PR
+can merge. The DRI merges it by hand; the gate clears automatically.
+
+> **Sequencing matters for the upcoming `freeze-branch` default flip:** once `release-lock` is
+> enforced (Phase 2), the `lock_branch` freeze becomes redundant. A future release of
+> `release-github-actions` will flip `freeze-branch`'s default from `true` to `false`. A repo
+> must reach Phase 2 **before** picking up that default flip, or it will briefly have neither
+> guard. Watch the release notes for that change.
+
+### The freeze survives lock-branch cycles
+
+`lock_branch.py` (lines 105–112) preserves all entries in `required_status_checks.contexts`
+on every freeze/unfreeze PUT — once `release-lock` is registered as a required check it is
+never dropped by the freeze/unfreeze cycle.
+
+### Migrating an existing repo
+
+If your repo already calls `automated-release.yml` and you want to adopt the gate:
+
+1. Run the `automated-release-setup` skill (`/automated-release-setup`) in your analyzer repo.
+2. When prompted, run Step 5c to add `release-lock.yml`.
+3. Trigger a release (dry-run is fine) and observe the `release-lock` status on any open PRs.
+4. Once satisfied, run Step 5d to register the check as required.
+5. The next release will gate non-bump PRs automatically.
+
+No changes to your `automated-release.yml` caller workflow are needed — the gate is entirely
+driven by the `release-lock.yml` you add to your repo.
 
 ## Setup
 

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -148,12 +148,13 @@ jobs:
   - Unlock the branch after the GitHub release is published — **before** the version-bump PR is created
   - Send lock/unlock notifications to the configured `slack-channel` if provided
   - **Note:** The freeze window ends before the version-bump PR is created (see [Release lock gate](#release-lock-gate) below for how to protect that window).
-- **Auto-merge sweep (always runs):** At the very start of every release, the workflow strips
-  auto-merge from all open PRs. This prevents the race where a pre-approved PR with auto-merge
-  enabled and CI still running would otherwise merge mid-release before the version-bump PR is
-  created. PR owners can re-enable auto-merge after the release. This is best-effort — a PR
-  that re-enables auto-merge and completes CI in the brief window before the version-bump PR
-  opens may still slip through; the release-lock gate (see below) guards against this.
+- **Auto-merge sweep (runs when `bump-version: true`):** When the release will create a
+  version-bump PR, the workflow strips auto-merge from all open PRs that have it enabled. This
+  prevents the race where a pre-approved PR with auto-merge enabled and CI still running would
+  otherwise merge mid-release before the version-bump PR opens. PR owners can re-enable
+  auto-merge after the release. This is best-effort — a PR that re-enables auto-merge and
+  completes CI in the brief window before the version-bump PR opens may still slip through;
+  the release-lock gate (see below) guards against this.
 - When `release-notes` is empty, Jira release notes are fetched and used.
 - Integration tickets and analyzer update PRs are created only if their respective flags are enabled and prerequisites are met.
 - Summaries:
@@ -188,8 +189,10 @@ unfrozen branch.
 
 ### The solution: `release-lock` required status check
 
-The "release in progress" signal is **"a version-bump PR is open."** A per-repo workflow
-(`release-lock.yml`) sets a `release-lock` commit status on every open PR:
+The "release in progress" signal is **"a version-bump PR is open."** A thin caller workflow
+(`release-lock.yml`) in each analyzer repo delegates to the reusable
+`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`, which sets a
+`release-lock` commit status on every open PR:
 
 | Condition | Status on other PRs | Status on bump PR |
 |---|---|---|
@@ -200,8 +203,9 @@ The "release in progress" signal is **"a version-bump PR is open."** A per-repo 
 The version-bump PR is identified by its head branch prefix
 `bot/prepare-next-development-iteration-` (invariant across Maven/Gradle/custom paths).
 
-When the bump PR closes, `release-lock.yml` sweeps all open PRs (paginated, drafts included)
+When the bump PR closes, the reusable workflow sweeps all open PRs (paginated, drafts included)
 and resets each to green **automatically** — developers do not need to push or retrigger.
+Logic updates propagate to all repos on the next `@v1` resolve; no per-repo changes needed.
 
 ### Adopt the gate (two-phase, per repo, via the setup skill)
 
@@ -211,7 +215,9 @@ and resets each to green **automatically** — developers do not need to push or
 
 #### Phase 1 — Add the workflow (unenforced)
 
-Run the `automated-release-setup` skill (Step 5c). It creates `release-lock.yml` in your repo.
+Run the `automated-release-setup` skill (Step 5c). It creates a thin `release-lock.yml` caller
+in your repo that delegates all logic to the reusable
+`SonarSource/release-github-actions/.github/workflows/release-lock.yml@v1`.
 The check reports green/red on PRs but is **not required**, so it gates nothing. Observe over
 one or two real releases that the statuses behave correctly (other PRs go red while a bump PR
 is open; all reset to green when it merges).
@@ -239,13 +245,15 @@ never dropped by the freeze/unfreeze cycle.
 If your repo already calls `automated-release.yml` and you want to adopt the gate:
 
 1. Run the `automated-release-setup` skill (`/automated-release-setup`) in your analyzer repo.
-2. When prompted, run Step 5c to add `release-lock.yml`.
+2. When prompted, run Step 5c to add `release-lock.yml` — a thin caller that delegates to
+   the reusable workflow in `release-github-actions`.
 3. Trigger a release (dry-run is fine) and observe the `release-lock` status on any open PRs.
 4. Once satisfied, run Step 5d to register the check as required.
 5. The next release will gate non-bump PRs automatically.
 
 No changes to your `automated-release.yml` caller workflow are needed — the gate is entirely
-driven by the `release-lock.yml` you add to your repo.
+driven by the `release-lock.yml` you add to your repo. Logic improvements in
+`release-github-actions` propagate automatically on the next `@v1` resolve.
 
 ## Setup
 


### PR DESCRIPTION
## Summary

- Adds a `disable-auto-merge` job at the start of `automated-release.yml` that strips auto-merge from all open PRs before the release touches anything. This closes the race where a pre-approved PR with pending CI would auto-merge into the branch before the version-bump PR is created.
- Adds Phase 1 (`release-lock.yml` template — unenforced status check) and Phase 2 (register as required check — gated/optional) to the `automated-release-setup` skill so teams can adopt the gate repo-by-repo without breaking anything.
- Documents the full release-lock gate in `README.md` and `docs/AUTOMATED_RELEASE.md` (problem, solution, rollout phases, freeze-coexistence guarantee, migration guide). Scoped to the analyzer path.

## What is NOT changed

- `ide-automated-release.yml` — untouched. DevEx releases behave exactly as before.
- `devex-release-setup/SKILL.md` — untouched.
- `freeze-branch` default — stays `true` (Phase 3 flip is deferred until release-lock is proven).

## How it works (non-breaking)

**Phase 0 (this PR):** The auto-merge sweep runs for all callers. The `release-lock.yml` workflow is added to each analyzer repo via the skill — unenforced (Phase 1), then registered as a required check when ready (Phase 2).

A repo that never runs the skill releases exactly as today.

See [GHA-347](https://sonarsource.atlassian.net/browse/GHA-347) for the full rollout plan.

## Test plan

- [ ] Non-adopter repo: triggers a release, confirms it runs as before; auto-merge is stripped from open PRs at start; no PR is blocked by a missing `release-lock` status.
- [ ] Phase 1 repo (after running skill Step 5c): `release-lock` shows on PRs but does not block merging.
- [ ] Phase 2 repo (after running skill Step 5d): while `bot/prepare-next-development-iteration-*` PR is open, other PRs are blocked; DRI merges bump PR; all PRs reset to green automatically, no retrigger.
- [ ] `ide-automated-release.yml` diff against `master` = zero changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[GHA-347]: https://sonarsource.atlassian.net/browse/GHA-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ