### PR TITLE
GHA-348 Close early-window gap: set release-lock at release start

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -282,6 +282,42 @@ jobs:
           done
           echo "Auto-merge sweep complete."
 
+  # Post release-lock=failure to all open PRs as soon as the release starts, closing the window
+  # between release trigger and bump PR creation where non-bump PRs could otherwise merge freely.
+  # Runs in parallel with disable-auto-merge and freeze-branch.
+  # When the bump PR opens, release-lock.yml re-fires and refines the statuses (bump PR → success,
+  # others stay failure). On bump PR close, release-lock.yml resets all to success.
+  set-release-lock:
+    name: Set release-lock on open PRs
+    if: ${{ inputs.bump-version }}
+    runs-on: ${{ inputs.runner-environment }}
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - name: Post release-lock failure to all open PRs
+        shell: bash
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          prs=$(gh pr list --state open --json number,headRefOid --jq '.[]')
+          if [ -z "$prs" ]; then
+            echo "No open PRs found."
+            exit 0
+          fi
+          echo "$prs" | while IFS= read -r pr_json; do
+            pr_number=$(echo "$pr_json" | jq -r '.number')
+            sha=$(echo "$pr_json" | jq -r '.headRefOid')
+            echo "Setting release-lock=failure on PR #$pr_number ($sha)"
+            gh api --method POST "repos/$REPO/statuses/$sha" \
+              -f state=failure \
+              -f context=release-lock \
+              -f description="Release in progress — merge the version-bump PR first"
+          done
+          echo "Release-lock sweep complete."
+
   # This job freezes the specified branch to prevent changes during the release process.
   freeze-branch:
     name: Freeze ${{ inputs.branch }} branch

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -302,7 +302,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          prs=$(gh pr list --state open --json number,headRefOid --jq '.[]')
+          prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
           if [ -z "$prs" ]; then
             echo "No open PRs found."
             exit 0
@@ -734,6 +734,42 @@ jobs:
           excluded-modules: ${{ inputs.bump-version-exclusions }}
           base-branch: ${{ inputs.branch }}
           tool: ${{ inputs.bump-version-tool }}
+
+  # Reset release-lock to success on all open PRs if the release was aborted before a bump PR
+  # was created. Without this, PRs would stay red indefinitely if releasability/prepare/publish
+  # fails — no bump PR is ever opened, so release-lock.yml's closed-event reset never fires.
+  # Only needed when bump-version is true (that's when set-release-lock ran).
+  # Skipped when bump-version succeeded: the bump PR's closed event will reset statuses instead.
+  clear-release-lock:
+    name: Clear release-lock on abort
+    needs: [ bump-version ]
+    if: ${{ always() && inputs.bump-version && needs.bump-version.result != 'success' }}
+    runs-on: ${{ inputs.runner-environment }}
+    permissions:
+      statuses: write
+      pull-requests: read
+    steps:
+      - name: Reset release-lock to success on all open PRs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
+          if [ -z "$prs" ]; then
+            echo "No open PRs found."
+            exit 0
+          fi
+          echo "$prs" | while IFS= read -r pr_json; do
+            pr_number=$(echo "$pr_json" | jq -r '.number')
+            sha=$(echo "$pr_json" | jq -r '.headRefOid')
+            echo "Resetting release-lock on PR #$pr_number ($sha)"
+            gh api --method POST "repos/$REPO/statuses/$sha" \
+              -f state=success \
+              -f context=release-lock \
+              -f description="No release in progress"
+          done
+          echo "Release-lock reset complete."
 
   # This step creates integration tickets in various Jira projects based on the inputs provided.
   # It creates tickets for SLVS, SLVSCODE, SLE, SLI, SQC, and SQS as specified.

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -286,7 +286,6 @@ jobs:
   freeze-branch:
     name: Freeze ${{ inputs.branch }} branch
     if: ${{ inputs.freeze-branch }}
-    needs: [ disable-auto-merge ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write
@@ -318,7 +317,7 @@ jobs:
       inputs.check-releasability &&
       !cancelled() &&
       (needs.freeze-branch.result == 'success' || needs.freeze-branch.result == 'skipped')
-    needs: [ disable-auto-merge, freeze-branch ]
+    needs: [ freeze-branch ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -286,6 +286,7 @@ jobs:
   freeze-branch:
     name: Freeze ${{ inputs.branch }} branch
     if: ${{ inputs.freeze-branch }}
+    needs: [ disable-auto-merge ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write
@@ -317,7 +318,7 @@ jobs:
       inputs.check-releasability &&
       !cancelled() &&
       (needs.freeze-branch.result == 'success' || needs.freeze-branch.result == 'skipped')
-    needs: [ freeze-branch ]
+    needs: [ disable-auto-merge, freeze-branch ]
     runs-on: ${{ inputs.runner-environment }}
     permissions:
       id-token: write

--- a/.github/workflows/release-lock.yml
+++ b/.github/workflows/release-lock.yml
@@ -52,17 +52,12 @@ jobs:
                 post_status "$sha" "success" "No release in progress"
               done <<< "$prs"
             else
-              # Bump PR opened/updated — mark itself green, all others red.
-              echo "Bump PR opened/updated. Setting bump PR green, all others red..."
+              # Bump PR opened/updated — mark itself green.
+              # Other open PRs were already set to failure by the release-start sweep
+              # in automated-release.yml (set-release-lock job). PRs that open after
+              # that sweep are handled by path B below when their own PR event fires.
+              echo "Bump PR opened/updated. Setting bump PR green..."
               post_status "$PR_HEAD_SHA" "success" "Version-bump PR — may merge"
-              prs=$(gh pr list --state open --json number,headRefOid --limit 1000 \
-                    --jq '.[] | "\(.number) \(.headRefOid)"')
-              while IFS=' ' read -r num sha; do
-                [ -z "$num" ] && continue
-                [ "$num" -eq "$PR_NUMBER" ] && continue  # skip bump PR itself
-                echo "  Blocking PR #$num (${sha:0:7})"
-                post_status "$sha" "failure" "Release in progress — merge the version-bump PR first"
-              done <<< "$prs"
             fi
           else
             # Normal PR event — check if a bump PR is currently open.


### PR DESCRIPTION
## Summary

- Adds a `set-release-lock` job to `automated-release.yml` that posts `release-lock=failure` to all open PRs immediately when the release is triggered — closing the ~10–20 min window between release trigger and bump PR creation where non-bump PRs could freely merge
- Adds a `clear-release-lock` cleanup job that resets all open PRs to green if the release is aborted before a bump PR is ever created (releasability failure, cancellation, etc.)
- Removes the now-redundant sweep from `release-lock.yml`'s bump-PR-opened path

## How the pieces fit together

```
release triggered
  └─ set-release-lock (new, parallel) → all open PRs: failure  ← closes early window
  └─ disable-auto-merge (parallel)    → strips pending auto-merge
  └─ freeze-branch (parallel, opt-in)
       └─ ... releasability, prepare, publish (~10-20 min) ...
            └─ bump-version → opens bot/prepare-next-development-iteration-* PR
                 └─ pull_request_target fires → release-lock.yml
                      bump PR → success
                      new PRs opened mid-release → self-assessed via path B

bump PR merged  → closed event → all open PRs reset to success  (happy path)
release aborted → clear-release-lock runs always() → all open PRs reset to success  (abort path)
```

`set-release-lock` and `clear-release-lock` are both gated on `inputs.bump-version`.

## What's NOT changed

`release-lock.yml`'s bump-PR-opened path previously re-swept all open PRs to failure on every bump PR event. That sweep is removed since it's redundant — the release-start job already set them. The closed-event reset and path B (normal PR self-assessment) are unchanged.

Closes GHA-348 (sub-task of GHA-347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)