### PR TITLE
GHA-352 Switch SQC integration from sonarcloud-core to sonar-plugins-deployer

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -132,10 +132,10 @@ on:
         type: boolean
         default: true
       sqc-plugins-deployer-integration:
-        description: "Also create a PR in sonar-plugins-deployer when sqc-integration is true. Disabled by default during the transition period."
+        description: "Deprecated, no-op. SQC integration now always uses sonar-plugins-deployer when sqc-integration is true."
         required: false
         type: boolean
-        default: false
+        default: true
       runner-environment:
         description: "Environment where the workflow will run"
         required: false
@@ -237,11 +237,8 @@ on:
         description: "URL of the SQS analyzer-update pull request"
         value: ${{ jobs.update-analyzers.outputs.sqs-pull-request-url }}
       sqc-pull-request-url:
-        description: "URL of the SQC analyzer-update pull request"
+        description: "URL of the SQC sonar-plugins-deployer pull request"
         value: ${{ jobs.update-analyzers.outputs.sqc-pull-request-url }}
-      plugins-deployer-pull-request-url:
-        description: "URL of the plugins-deployer pull request"
-        value: ${{ jobs.update-analyzers.outputs.plugins-deployer-pull-request-url }}
       sqaa-pull-request-url:
         description: "URL of the SQAA analyzer-update pull request"
         value: ${{ jobs.update-analysis-as-a-service.outputs.pull-request-url }}
@@ -927,8 +924,7 @@ jobs:
       id-token: write
     outputs:
       sqs-pull-request-url: ${{ steps.update-sqs.outputs.pull-request-url }}
-      sqc-pull-request-url: ${{ steps.update-sqc.outputs.pull-request-url }}
-      plugins-deployer-pull-request-url: ${{ steps.update-plugins-deployer.outputs.pull-request-url }}
+      sqc-pull-request-url: ${{ steps.update-plugins-deployer.outputs.pull-request-url }}
     steps:
       - name: Update analyzer in SQS
         id: update-sqs
@@ -943,23 +939,10 @@ jobs:
           draft: ${{ inputs.is-draft-release }}
           reviewers: ${{ github.actor }}
 
-      - name: Update analyzer in SQC
-        id: update-sqc
-        if: ${{ inputs.sqc-integration }}
-        uses: SonarSource/release-github-actions/update-analyzer@master
-        with:
-          release-version: ${{ needs.prepare-release.outputs.release-version }}
-          ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}
-          plugin-name: ${{ inputs.plugin-name }}
-          secret-name: ${{ inputs.release-automation-secret-name || format('sonar-{0}-release-automation', inputs.plugin-name) }}
-          plugin-artifacts: ${{inputs.plugin-artifacts-sqc }}
-          draft: ${{ inputs.is-draft-release }}
-          reviewers: ${{ github.actor }}
-
       - name: Update analyzer in sonar-plugins-deployer
         id: update-plugins-deployer
-        if: ${{ inputs.sqc-integration && inputs.sqc-plugins-deployer-integration }}
-        uses: SonarSource/release-github-actions/update-plugins-deployer@master
+        if: ${{ inputs.sqc-integration }}
+        uses: SonarSource/release-github-actions/update-plugins-deployer@v1
         with:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}
@@ -979,7 +962,6 @@ jobs:
           RELEASE_AUTOMATION_SECRET_NAME: ${{ inputs.release-automation-secret-name }}
           SQS_INTEGRATION: ${{ inputs.sqs-integration == true && 'true' || 'false' }}
           SQC_INTEGRATION: ${{ inputs.sqc-integration == true && 'true' || 'false' }}
-          SQC_PLUGINS_DEPLOYER_INTEGRATION: ${{ inputs.sqc-plugins-deployer-integration == true && 'true' || 'false' }}
         run: |
           echo "## 🔄 Update Analyzers" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -990,8 +972,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           if [ "$SQS_INTEGRATION" = "true" ]; then echo "- SQS PR: ${{ steps.update-sqs.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
-          if [ "$SQC_INTEGRATION" = "true" ]; then echo "- SQC PR: ${{ steps.update-sqc.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
-          if [ "$SQC_INTEGRATION" = "true" ] && [ "$SQC_PLUGINS_DEPLOYER_INTEGRATION" = "true" ]; then echo "- Plugins Deployer PR: ${{ steps.update-plugins-deployer.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
+          if [ "$SQC_INTEGRATION" = "true" ]; then echo "- SQC PR (sonar-plugins-deployer): ${{ steps.update-plugins-deployer.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY; fi
 
   # This step updates analyzer versions in Analysis as a Service by creating a pull request.
   update-analysis-as-a-service:
@@ -1077,7 +1058,6 @@ jobs:
           SQC_TICKET_URL: ${{ needs.create-integration-tickets.outputs.sqc-ticket-url || 'not created' }}
           SQS_PR_URL: ${{ needs.update-analyzers.outputs.sqs-pull-request-url || 'not created' }}
           SQC_PR_URL: ${{ needs.update-analyzers.outputs.sqc-pull-request-url || 'not created' }}
-          PLUGINS_DEPLOYER_PR_URL: ${{ inputs.sqc-plugins-deployer-integration == true && needs.update-analyzers.outputs.plugins-deployer-pull-request-url || 'not created' }}
           SQAA_PR_URL: ${{ inputs.sqaa-integration == true && needs.update-analysis-as-a-service.outputs.pull-request-url || 'not created' }}
           BUMP_VERSION_PR_URL: ${{ needs.bump-version.outputs.pull-request-url || 'not created' }}
           RESULT_CHECK_RELEASABILITY: ${{ needs.check-releasability.result }}
@@ -1124,14 +1104,13 @@ jobs:
             echo "  - SQS Integration Ticket: $SQS_TICKET_URL"
             echo "  - SQC Integration Ticket: $SQC_TICKET_URL"
             echo "  - SQS Analyzer PR: $SQS_PR_URL"
-            echo "  - SQC Analyzer PR: $SQC_PR_URL"
-            echo "  - Plugins Deployer PR: $PLUGINS_DEPLOYER_PR_URL"
+            echo "  - SQC Analyzer PR (sonar-plugins-deployer): $SQC_PR_URL"
             echo "  - SQAA Analyzer PR: $SQAA_PR_URL"
             echo "  - Bump Version PR: $BUMP_VERSION_PR_URL"
 
             echo "## Guidance"
             if [[ "$ALL_SUCCESS" == "true" ]]; then
-              echo "- Review and merge the bump version, SQS, SQC, Plugins Deployer, and SQAA PRs."
+              echo "- Review and merge the bump version, SQS, SQC, and SQAA PRs."
               echo "- Update integration ticket statuses (ensure SQS ticket fix versions are set)."
             else
               echo "- Check failed jobs for error messages and re-run as needed."

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -66,6 +66,7 @@ This workflow composes several actions from this repository:
 | `sqs-integration`            | Create SQS integration ticket and PR                                                                            | No       | `true`       |
 | `sqc-integration`            | Create SQC integration ticket and PR                                                                            | No       | `true`       |
 | `sqaa-integration`           | Create SQAA PR in sonar-analysis-as-a-service. Runs when both this and `sqc-integration` are true. Skipped silently if the analyzer is not yet onboarded to SQAA. | No       | `true`       |
+| `sqc-plugins-deployer-integration` | Deprecated, no-op. SQC integration always uses sonar-plugins-deployer.                                  | No       | `true`       |
 | `ktlo-jira-project-key`      | Jira project key where the KTLO epic lives. Defaults to `jira-project-key` if not provided.                    | No       | -            |
 | `ktlo-epic-name-pattern`     | Regex pattern to match the KTLO epic summary                                                                    | No       | `KTLO`       |
 | `runner-environment`         | Runner labels/environment                                                                                       | No       | `sonar-m`    |
@@ -272,7 +273,7 @@ To set up this workflow in your repository, you need to complete the following p
      ```yaml
      release_automation: &release_automation
        suffix: release-automation
-       description: access to sonar-enterprise and sonarcloud-core repositories to create PRs to update analyzers
+       description: access to sonar-enterprise and sonar-plugins-deployer repositories to create PRs to update analyzers
        organization: SonarSource
        permissions:
          contents: write
@@ -281,7 +282,7 @@ To set up this workflow in your repository, you need to complete the following p
    - Add to your repository's `github.customs` section:
      ```yaml
      - <<: *release_automation
-       repositories: [your-repo-name, sonar-enterprise, sonarcloud-core]
+       repositories: [your-repo-name, sonar-enterprise, sonar-plugins-deployer]
      ```
    - Example PR: https://github.com/SonarSource/re-terraform-aws-vault/pull/8406
 
@@ -366,7 +367,7 @@ Artifacts from Repox can be attached to the GitHub release draft using the `rele
 
 - Review and merge the bump-version PR
 - Review and merge the SQS PR in sonar-enterprise
-- Review and merge the SQC PR in sonarcloud-core
+- Review and merge the SQC PR in sonar-plugins-deployer
 - Update integration ticket statuses in Jira
 - Set fix versions on the SONAR ticket
 


### PR DESCRIPTION
## Context

Analysis Processing announced (June 26, 2026) that `sonarcloud-core` is frozen for plugin upgrades effective **Monday June 29, 2026 at 9 AM CEST**. All SQC plugin upgrade PRs must go to `SonarSource/sonar-plugins-deployer` instead. The shift gives analyzer teams full autonomy and reduces deployment times.

The `update-plugins-deployer` action already existed as a transition opt-in. This PR makes it the sole SQC path.

Jira: https://sonarsource.atlassian.net/browse/GHA-352

## Changes

- **Remove** the "Update analyzer in SQC" step that targeted `sonarcloud-core` via `update-analyzer`
- **Simplify** "Update analyzer in sonar-plugins-deployer" to gate on `sqc-integration` alone (no extra flag)
- **`sqc-pull-request-url`** workflow output now points to the plugins-deployer PR
- **`sqc-plugins-deployer-integration`** kept as a no-op deprecated stub (backwards compat for callers)
- **Docs** updated: vault repo list, post-release checklist, inputs table

## Follow-up

GHA-353 tracks removing the now-dead `SC-*` branch from `update-analyzer/action.yml`.

## Test plan

- [ ] CI passes on this PR
- [ ] Verify a test release triggers a PR on `sonar-plugins-deployer` (not `sonarcloud-core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)