### PR TITLE
GHA-355 Fix release workflow missing workflows permission for v1 bran…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      workflows: write
     steps:
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/GHA-355

## Problem

The `release.yml` job pushes the `v1` branch after pinning internal action refs to the release SHA. That push includes `.github/workflows/automated-release.yml`, which requires the `workflows` permission. Without it, the GitHub App token is rejected:

```
refusing to allow a GitHub App to create or update workflow without `workflows` permission
```

Uncovered when GHA-352 added changes to `automated-release.yml` that got picked up by the v1 snapshot pinning step.

## Fix

Add `workflows: write` to the `update-version-branch` job permissions block in `release.yml`.

## Test plan

- [ ] Trigger a new release and verify the `v1` branch push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Workflow configuration:**
  - Deprecated `sqc-plugins-deployer-integration` input as the SQC integration now defaults to using `sonar-plugins-deployer`.
  - Updated `automated-release.yml` to streamline the SQC integration flow by removing redundant steps and logic.
- **Documentation updates:**
  - Reflected changes in `AUTOMATED_RELEASE.md` regarding the deprecated input and updated repository requirements for `sonar-plugins-deployer`.

<sub>This will update automatically on new commits.</sub>