### PR TITLE
GHA-355 Fix release workflow missing workflows permission for v1 branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,19 @@ jobs:
     name: Update version branch
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      workflows: write
+      id-token: write
     steps:
+      - name: Get vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/SonarSource-release-github-actions-release token | GITHUB_TOKEN;
+
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Pass token so that git push is authenticated without needing to rewrite the remote URL manually
-          token: ${{ github.token }}
+          token: ${{ fromJSON(steps.secrets.outputs.vault).GITHUB_TOKEN }}
 
       - name: Update version branch
         shell: bash


### PR DESCRIPTION
Jira: https://sonarsource.atlassian.net/browse/GHA-355

## Problem

The `release.yml` job pushes the `v1` branch after pinning internal action refs to the release SHA. That push includes `.github/workflows/automated-release.yml`. GitHub Apps (including the built-in `github.token`) **cannot push workflow files** without the `workflows` permission granted at the App installation level — this is not a `GITHUB_TOKEN` scope, so no `permissions:` block in YAML can fix it.

Uncovered when GHA-352 added changes to `automated-release.yml` that got picked up by the v1 snapshot pinning step.

## Fix

Switch from `github.token` to a Vault-sourced token (`SonarSource-release-github-actions-release`) that has `contents: write` and `workflows: write`.

The vault entry is added in: https://github.com/SonarSource/re-terraform-aws-vault/pull/9368

> **Note:** This PR depends on the vault PR being merged and applied first.

## Test plan

- [x] Vault PR #9368 merged
- [ ] Trigger a new release and verify the `v1` branch push succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)