### PR TITLE
Remove grep-based static tests from test-update-analysis-as-a-service

### DIFF
--- a/.github/workflows/test-update-analysis-as-a-service.yml
+++ b/.github/workflows/test-update-analysis-as-a-service.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - master
-      - v*
     paths:
       - 'update-analysis-as-a-service/**'
       - '.github/workflows/automated-release.yml'

--- a/.github/workflows/test-update-analysis-as-a-service.yml
+++ b/.github/workflows/test-update-analysis-as-a-service.yml
@@ -10,6 +10,7 @@ on:
   push:
     branches:
       - master
+      - v*
     paths:
       - 'update-analysis-as-a-service/**'
       - '.github/workflows/automated-release.yml'
@@ -49,5 +50,5 @@ jobs:
 
       - name: Verify action creates a pull request
         run: |
-          grep -q "SonarSource/release-github-actions/create-pull-request@master" update-analysis-as-a-service/action.yml
+          grep -qE "SonarSource/release-github-actions/create-pull-request@(master|[0-9a-f]{40})" update-analysis-as-a-service/action.yml
           grep -q "SonarSource/sonar-analysis-as-a-service" update-analysis-as-a-service/action.yml

--- a/.github/workflows/test-update-analysis-as-a-service.yml
+++ b/.github/workflows/test-update-analysis-as-a-service.yml
@@ -29,26 +29,4 @@ jobs:
       - name: Run shell unit tests
         run: bash update-analysis-as-a-service/test_update_libs_versions_toml.sh
 
-  static-tests:
-    name: Static Tests
-    runs-on: github-ubuntu-latest-s
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Verify reusable workflow exposes SQAA integration
-        run: |
-          grep -q "sqaa-integration:" .github/workflows/automated-release.yml
-          grep -q "plugin-artifacts-sqaa:" .github/workflows/automated-release.yml
-          grep -q "sqaa-base-branch:" .github/workflows/automated-release.yml
-          grep -q "sqaa-reviewers:" .github/workflows/automated-release.yml
-          grep -q "sqaa-pull-request-url:" .github/workflows/automated-release.yml
-          grep -q "Update analyzer in Analysis as a Service" .github/workflows/automated-release.yml
-          grep -q "base-branch: .*sqaa-base-branch" .github/workflows/automated-release.yml
-          grep -q "reviewers: .*sqaa-reviewers" .github/workflows/automated-release.yml
-
-      - name: Verify action creates a pull request
-        run: |
-          grep -qE "SonarSource/release-github-actions/create-pull-request@(master|[0-9a-f]{40})" update-analysis-as-a-service/action.yml
-          grep -q "SonarSource/sonar-analysis-as-a-service" update-analysis-as-a-service/action.yml


### PR DESCRIPTION
## Summary

- Remove the `static-tests` job from `test-update-analysis-as-a-service.yml` — it only grepped for string literals in YAML files, which adds friction without covering real behavior (unit tests do that).

The grep for `@master` was also fragile on `v1` where refs are pinned to the release SHA, causing a spurious failure after every release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)