### PR TITLE
GHA-355 Use vault token for statuses writes to remove statuses: write requirement from callers

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -289,14 +289,19 @@ jobs:
     if: ${{ inputs.bump-version }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      statuses: write
+      id-token: write
       pull-requests: read
     steps:
+      - name: Get Secrets from Vault
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-lock token | GITHUB_LOCK_TOKEN;
       - name: Post release-lock failure to all open PRs
         shell: bash
         env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_LOCK_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
@@ -743,13 +748,19 @@ jobs:
     if: ${{ always() && inputs.bump-version && needs.bump-version.result != 'success' }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      statuses: write
+      id-token: write
       pull-requests: read
     steps:
+      - name: Get Secrets from Vault
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/github/token/{REPO_OWNER_NAME_DASH}-lock token | GITHUB_LOCK_TOKEN;
       - name: Reset release-lock to success on all open PRs
         shell: bash
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_LOCK_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')


### PR DESCRIPTION
## Summary

- `set-release-lock` and `clear-release-lock` jobs now use the vault `-lock` token instead of `github.token` for posting commit statuses
- Removes the `statuses: write` permission declaration from both jobs (replaced with `id-token: write` for vault access)
- Callers of `automated-release.yml@v1` no longer need to grant `statuses: write` — this fixes the validation error seen in sonar-security and other repos

## Problem

Repos calling `automated-release.yml@v1` with `statuses: read` in their permissions block were getting:

> The workflow is not valid. Error calling workflow: The nested job 'set-release-lock' is requesting 'statuses: write', but is only allowed 'statuses: read'.

GitHub validates declared permissions at parse time, so even jobs guarded by `if: inputs.bump-version` would cause the entire workflow call to be rejected.

## Solution

Use the vault lock token (`{REPO_OWNER_NAME_DASH}-lock`) — the same token used by `lock-branch` — to authenticate the statuses API calls. This token has the necessary permissions without requiring callers to grant `statuses: write` to the GITHUB_TOKEN.

## Test plan

- [ ] Verify the workflow runs without permission errors in a repo that has `statuses: read`
- [ ] Verify `set-release-lock` correctly posts failure status to open PRs when `bump-version: true`
- [ ] Verify `clear-release-lock` correctly resets statuses on abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)