### PR TITLE
GHA-366 Fix incorrect CLI option causing disable-auto-merge step to crash

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -275,7 +275,7 @@ jobs:
           fi
           for pr in $pr_numbers; do
             echo "Disabling auto-merge on PR #$pr"
-            gh pr merge "$pr" --disable-auto-merge
+            gh pr merge "$pr" --disable-auto
           done
           echo "Auto-merge sweep complete."
 


### PR DESCRIPTION
This should address [a failure](https://github.com/SonarSource/sonar-dataflow-bug-detection/actions/runs/28525266764/job/84559882397) of the automated release actions when auto-merge PRs are active:

<img width="842" height="575" alt="image" src="https://github.com/user-attachments/assets/ef455340-88ae-4671-8781-1170c2f7001f" />

Apparently the used GH cli option was incorrect, or the name of the option changed.
The fix still needs to be tested.