### PR TITLE
GHA-355 Use github.token for release-lock (drop Vault *-lock token)

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -289,7 +289,6 @@ jobs:
     if: ${{ inputs.bump-version }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      statuses: write
       pull-requests: read
     steps:
       - name: Post release-lock failure to all open PRs
@@ -752,7 +751,6 @@ jobs:
     if: ${{ always() && inputs.bump-version && needs.bump-version.result != 'success' }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      statuses: write
       pull-requests: read
     steps:
       - name: Reset release-lock to success on all open PRs

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -289,21 +289,25 @@ jobs:
     if: ${{ inputs.bump-version }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      id-token: write
+      statuses: write
       pull-requests: read
     steps:
-      - name: Get Secrets from Vault
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-lock token | GITHUB_LOCK_TOKEN;
       - name: Post release-lock failure to all open PRs
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_LOCK_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
+          # Preflight: confirm the token has statuses:write. Consumers that have not
+          # yet granted this permission get a warning but the release proceeds normally.
+          # Self-heals once the caller job adds `statuses: write` to its permissions.
+          if ! gh api --method POST "repos/$REPO/statuses/$GITHUB_SHA" \
+                -f state=success -f context=release-lock \
+                -f description="Release in progress" >/dev/null 2>&1; then
+            echo "::warning::Token lacks statuses:write on $REPO — skipping release-lock sweep." \
+                 "Add 'statuses: write' to the caller job's permissions to enable the release lock."
+            exit 0
+          fi
           prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
           if [ -z "$prs" ]; then
             echo "No open PRs found."
@@ -748,19 +752,13 @@ jobs:
     if: ${{ always() && inputs.bump-version && needs.bump-version.result != 'success' }}
     runs-on: ${{ inputs.runner-environment }}
     permissions:
-      id-token: write
+      statuses: write
       pull-requests: read
     steps:
-      - name: Get Secrets from Vault
-        id: secrets
-        uses: SonarSource/vault-action-wrapper@v3
-        with:
-          secrets: |
-            development/github/token/{REPO_OWNER_NAME_DASH}-lock token | GITHUB_LOCK_TOKEN;
       - name: Reset release-lock to success on all open PRs
         shell: bash
         env:
-          GH_TOKEN: ${{ steps.secrets.outputs.GITHUB_LOCK_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
@@ -772,10 +770,14 @@ jobs:
             pr_number=$(echo "$pr_json" | jq -r '.number')
             sha=$(echo "$pr_json" | jq -r '.headRefOid')
             echo "Resetting release-lock on PR #$pr_number ($sha)"
-            gh api --method POST "repos/$REPO/statuses/$sha" \
-              -f state=success \
-              -f context=release-lock \
-              -f description="No release in progress"
+            # A 403 here means the caller never granted statuses:write; no lock was
+            # ever set, so there is nothing to clear — warn and continue.
+            if ! gh api --method POST "repos/$REPO/statuses/$sha" \
+                  -f state=success \
+                  -f context=release-lock \
+                  -f description="No release in progress" >/dev/null 2>&1; then
+              echo "::warning::Could not reset release-lock on PR #$pr_number ($sha) — token may lack statuses:write. Skipping."
+            fi
           done
           echo "Release-lock reset complete."
 

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -307,7 +307,7 @@ jobs:
                  "Add 'statuses: write' to the caller job's permissions to enable the release lock."
             exit 0
           fi
-          prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
+          prs=$(gh pr list --repo "$REPO" --state open --json number,headRefOid --limit 1000 --jq '.[]')
           if [ -z "$prs" ]; then
             echo "No open PRs found."
             exit 0
@@ -759,7 +759,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
-          prs=$(gh pr list --state open --json number,headRefOid --limit 1000 --jq '.[]')
+          prs=$(gh pr list --repo "$REPO" --state open --json number,headRefOid --limit 1000 --jq '.[]')
           if [ -z "$prs" ]; then
             echo "No open PRs found."
             exit 0


### PR DESCRIPTION
## Problem

The `set-release-lock` and `clear-release-lock` jobs were fetching a dedicated Vault GitHub-App token (`development/github/token/<repo>-lock`) so that consumer caller workflows would not need `statuses: write`. This broke on sonar-pli (our guinea-pig): the backing GitHub App (installation `58302986`) is not installed/granted on `sonar-pli`, so Vault returns an empty token → `gh` exits with code 4 → the whole dry-run cancels.

The root cause is a design problem: every analyzer repo must have the App provisioned and installed before release-lock works — a recurring per-analyzer onboarding burden and a silent-empty-token failure mode.

## Solution

Drop the Vault `*-lock` token entirely. Both jobs now use `${{ github.token }}` directly — the same model that `release-lock.yml` (Phase 1) already uses. No Vault secret, no GitHub App, no per-repo provisioning.

Each consumer's caller job must grant `statuses: write` (was `statuses: read`). This reverses GHA-355's goal of removing `statuses: write` from callers, but one permission line per consumer is far cheaper than per-repo App provisioning.

## Migration guard

For consumers that haven't yet granted `statuses: write`, `set-release-lock` preflights with a test POST before the sweep. On `403` it logs a warning and `exit 0` — the release continues unblocked, the lock is simply not set. Self-heals once the caller opts in. `clear-release-lock` similarly tolerates `403` on individual PR resets.

## Changes

- `set-release-lock`: `id-token: write` → `statuses: write`; drop Vault step; use `github.token`; add preflight guard.
- `clear-release-lock`: same permission/Vault/token swap; per-PR `403` tolerance.

Reverses #176 / #177 (GHA-355 Vault-token approach).

## Test plan

- [ ] Dry-run on sonar-pli with `statuses: write` granted — `set-release-lock` posts statuses, no Vault step, no exit 4.
- [x] Dry-run on a caller without `statuses: write` — job logs warning and exits 0, rest of release proceeds.