### PR TITLE
GHA-355 Revert github.token approach for release-lock sweep

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -291,7 +291,7 @@ jobs:
     steps:
       - name: Skipped
         shell: bash
-        run: echo "Skipped — release-lock status sweep requires statuses:write on the lock token (pending re-terraform-aws-vault update)"
+        run: echo "Skipped — release-lock status sweep requires statuses:write on the lock token"
 
   # This job freezes the specified branch to prevent changes during the release process.
   freeze-branch:
@@ -723,7 +723,7 @@ jobs:
     steps:
       - name: Skipped
         shell: bash
-        run: echo "Skipped — release-lock status reset requires statuses:write on the lock token (pending re-terraform-aws-vault update)"
+        run: echo "Skipped — release-lock status reset requires statuses:write on the lock token"
 
   # This step creates integration tickets in various Jira projects based on the inputs provided.
   # It creates tickets for SLVS, SLVSCODE, SLE, SLI, SQC, and SQS as specified.

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -288,40 +288,10 @@ jobs:
     name: Set release-lock on open PRs
     if: ${{ inputs.bump-version }}
     runs-on: ${{ inputs.runner-environment }}
-    permissions:
-      pull-requests: read
     steps:
-      - name: Post release-lock failure to all open PRs
+      - name: Skipped
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Preflight: confirm the token has statuses:write. Consumers that have not
-          # yet granted this permission get a warning but the release proceeds normally.
-          # Self-heals once the caller job adds `statuses: write` to its permissions.
-          if ! gh api --method POST "repos/$REPO/statuses/$GITHUB_SHA" \
-                -f state=success -f context=release-lock \
-                -f description="Release in progress" >/dev/null 2>&1; then
-            echo "::warning::Token lacks statuses:write on $REPO — skipping release-lock sweep." \
-                 "Add 'statuses: write' to the caller job's permissions to enable the release lock."
-            exit 0
-          fi
-          prs=$(gh pr list --repo "$REPO" --state open --json number,headRefOid --limit 1000 --jq '.[]')
-          if [ -z "$prs" ]; then
-            echo "No open PRs found."
-            exit 0
-          fi
-          echo "$prs" | while IFS= read -r pr_json; do
-            pr_number=$(echo "$pr_json" | jq -r '.number')
-            sha=$(echo "$pr_json" | jq -r '.headRefOid')
-            echo "Setting release-lock=failure on PR #$pr_number ($sha)"
-            gh api --method POST "repos/$REPO/statuses/$sha" \
-              -f state=failure \
-              -f context=release-lock \
-              -f description="Release in progress — merge the version-bump PR first"
-          done
-          echo "Release-lock sweep complete."
+        run: echo "Skipped — release-lock status sweep requires statuses:write on the lock token (pending re-terraform-aws-vault update)"
 
   # This job freezes the specified branch to prevent changes during the release process.
   freeze-branch:
@@ -750,34 +720,10 @@ jobs:
     needs: [ bump-version ]
     if: ${{ always() && inputs.bump-version && needs.bump-version.result != 'success' }}
     runs-on: ${{ inputs.runner-environment }}
-    permissions:
-      pull-requests: read
     steps:
-      - name: Reset release-lock to success on all open PRs
+      - name: Skipped
         shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-        run: |
-          prs=$(gh pr list --repo "$REPO" --state open --json number,headRefOid --limit 1000 --jq '.[]')
-          if [ -z "$prs" ]; then
-            echo "No open PRs found."
-            exit 0
-          fi
-          echo "$prs" | while IFS= read -r pr_json; do
-            pr_number=$(echo "$pr_json" | jq -r '.number')
-            sha=$(echo "$pr_json" | jq -r '.headRefOid')
-            echo "Resetting release-lock on PR #$pr_number ($sha)"
-            # A 403 here means the caller never granted statuses:write; no lock was
-            # ever set, so there is nothing to clear — warn and continue.
-            if ! gh api --method POST "repos/$REPO/statuses/$sha" \
-                  -f state=success \
-                  -f context=release-lock \
-                  -f description="No release in progress" >/dev/null 2>&1; then
-              echo "::warning::Could not reset release-lock on PR #$pr_number ($sha) — token may lack statuses:write. Skipping."
-            fi
-          done
-          echo "Release-lock reset complete."
+        run: echo "Skipped — release-lock status reset requires statuses:write on the lock token (pending re-terraform-aws-vault update)"
 
   # This step creates integration tickets in various Jira projects based on the inputs provided.
   # It creates tickets for SLVS, SLVSCODE, SLE, SLI, SQC, and SQS as specified.


### PR DESCRIPTION
## Summary

Reverts the \`github.token\` enrichment approach for \`set-release-lock\` / \`clear-release-lock\` (c5fffab, bba249e, bd70c78, 7475caa), returning both jobs to their stubbed no-op state.

## Why

GitHub's reusable workflow permission model does not forward caller-granted permissions (e.g. \`statuses: write\`) to nested job tokens unless the reusable workflow itself declares a top-level \`permissions:\` block. Without that block, the job token only carries \`Metadata: read\` regardless of what the caller grants. Adding a top-level block introduces a new problem: all nested jobs inherit the same ceiling, which breaks jobs that need tighter scopes.

This was confirmed on sonar-pli: even after granting \`statuses: write\` in the caller, the \`set-release-lock\` job token had no write access and logged the warning.

## What's next

The \`set-release-lock\` / \`clear-release-lock\` sweep (Phase 0) remains stubbed pending a solution that doesn't depend on permission propagation through reusable workflow boundaries (e.g. a correctly provisioned Vault GitHub App token).

In the meantime, the per-analyzer \`statuses: write\` PRs have been reopened under [GHA-368](https://sonarsource.atlassian.net/browse/GHA-368) so the permission is in place before the sweep is activated.

[GHA-368]: https://sonarsource.atlassian.net/browse/GHA-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ