### PR TITLE
CLP-127 Make the 'sonar-' prefix optional in update-plugins-deployer anchor keys

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -23,6 +23,11 @@ on:
         description: "Plugin name"
         required: true
         type: string
+      sonar-prefix:
+        description: "Whether the plugin anchor key in sonar-plugins-deployer is prefixed with sonar-"
+        required: false
+        type: boolean
+        default: true
       plugin-artifacts-sqs:
         description: "SQS Plugin artifacts"
         required: false
@@ -904,6 +909,7 @@ jobs:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}
           plugin-name: ${{ inputs.plugin-name }}
+          sonar-prefix: ${{ inputs.sonar-prefix }}
           secret-name: ${{ inputs.release-automation-secret-name || format('sonar-{0}-release-automation', inputs.plugin-name) }}
           draft: ${{ inputs.is-draft-release }}
           reviewers: ${{ github.actor }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -899,7 +899,7 @@ jobs:
       - name: Update analyzer in sonar-plugins-deployer
         id: update-plugins-deployer
         if: ${{ inputs.sqc-integration }}
-        uses: SonarSource/release-github-actions/update-plugins-deployer@v1
+        uses: SonarSource/release-github-actions/update-plugins-deployer@ac/CLP-127
         with:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -23,7 +23,7 @@ on:
         description: "Plugin name"
         required: true
         type: string
-      sonar-prefix:
+      set-sonar-prefix:
         description: "Whether the plugin anchor key in sonar-plugins-deployer is prefixed with sonar-"
         required: false
         type: boolean
@@ -909,7 +909,7 @@ jobs:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}
           plugin-name: ${{ inputs.plugin-name }}
-          sonar-prefix: ${{ inputs.sonar-prefix }}
+          set-sonar-prefix: ${{ inputs.set-sonar-prefix }}
           secret-name: ${{ inputs.release-automation-secret-name || format('sonar-{0}-release-automation', inputs.plugin-name) }}
           draft: ${{ inputs.is-draft-release }}
           reviewers: ${{ github.actor }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -904,7 +904,7 @@ jobs:
       - name: Update analyzer in sonar-plugins-deployer
         id: update-plugins-deployer
         if: ${{ inputs.sqc-integration }}
-        uses: SonarSource/release-github-actions/update-plugins-deployer@ac/CLP-127
+        uses: SonarSource/release-github-actions/update-plugins-deployer@v1
         with:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           ticket-key: ${{ needs.create-integration-tickets.outputs.sqc-ticket-key }}

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -42,6 +42,7 @@ This workflow composes several actions from this repository:
 | `jira-project-key`           | Jira project key                                                                                                | Yes      | -            |
 | `project-name`               | Display name of the project                                                                                     | Yes      | -            |
 | `plugin-name`                | Plugin name                                                                                                     | Yes      | -            |
+| `sonar-prefix`               | Whether the plugin anchor key in `sonar-plugins-deployer` is prefixed with `sonar-`                             | No       | `true`       |
 | `plugin-artifacts-sqs`       | Artifact identifier(s) for SQS; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqc`       | Artifact identifier(s) for SQC; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqaa`      | Artifact identifier(s) for SQAA; falls back to `plugin-name`                                                    | No       | -            |

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -42,7 +42,7 @@ This workflow composes several actions from this repository:
 | `jira-project-key`           | Jira project key                                                                                                | Yes      | -            |
 | `project-name`               | Display name of the project                                                                                     | Yes      | -            |
 | `plugin-name`                | Plugin name                                                                                                     | Yes      | -            |
-| `sonar-prefix`               | Whether the plugin anchor key in `sonar-plugins-deployer` is prefixed with `sonar-`                             | No       | `true`       |
+| `set-sonar-prefix`           | Whether the plugin anchor key in `sonar-plugins-deployer` is prefixed with `sonar-`                             | No       | `true`       |
 | `plugin-artifacts-sqs`       | Artifact identifier(s) for SQS; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqc`       | Artifact identifier(s) for SQC; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqaa`      | Artifact identifier(s) for SQAA; falls back to `plugin-name`                                                    | No       | -            |

--- a/update-plugins-deployer/README.md
+++ b/update-plugins-deployer/README.md
@@ -57,7 +57,7 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 
 General rule: strip `-enterprise` suffix, then prepend `sonar-` when `sonar-prefix` is `true` (the default). Exceptions:
 - `dotnet-enterprise` maps to `sonar-dotnet` (covers both `csharp-enterprise` and `vbnet-enterprise` via aliases).
-- Plugins whose anchor is **not** prefixed with `sonar-` (e.g. `java-a3s-context-collector`) must be updated by passing `sonar-prefix: 'false'`.
+- Plugins whose anchor is **not** prefixed with `sonar-` (e.g. `java-a3s-context-collector`) must be updated by passing `sonar-prefix: false`.
 
 ## Usage
 

--- a/update-plugins-deployer/README.md
+++ b/update-plugins-deployer/README.md
@@ -52,8 +52,11 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 | `python-enterprise` | `sonar-python` |
 | `dotnet-enterprise` | `sonar-dotnet` |
 | `php`, `kotlin`, etc. | `sonar-{plugin-name}` |
+| `java-a3s-context-collector` | `java-a3s-context-collector` |
 
-General rule: strip `-enterprise` suffix, prepend `sonar-`. Exception: `dotnet-enterprise` maps to `sonar-dotnet` (covers both `csharp-enterprise` and `vbnet-enterprise` via aliases).
+General rule: strip `-enterprise` suffix, prepend `sonar-`. Exceptions:
+- `dotnet-enterprise` maps to `sonar-dotnet` (covers both `csharp-enterprise` and `vbnet-enterprise` via aliases).
+- `java-a3s-context-collector` keeps its name as-is — its anchor is **not** prefixed with `sonar-`.
 
 ## Usage
 

--- a/update-plugins-deployer/README.md
+++ b/update-plugins-deployer/README.md
@@ -28,6 +28,7 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 | `release-version` | The new version to set (e.g. `1.12.0.12345`) | Yes | |
 | `ticket-key` | Jira ticket number. Must start with `SC-`. | Yes | |
 | `plugin-name` | Plugin language key, used for the anchor lookup, PR title, commit and branch name | Yes | |
+| `sonar-prefix` | Whether the anchor key is prefixed with `sonar-` (`true`/`false`) | No | `true` |
 | `secret-name` | Vault secret name granting write access to `sonar-plugins-deployer` | Yes | |
 | `base-branch` | Base branch for the PR | No | `master` |
 | `draft` | Create PR as draft (`true`/`false`) | No | `false` |
@@ -54,9 +55,9 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 | `php`, `kotlin`, etc. | `sonar-{plugin-name}` |
 | `java-a3s-context-collector` | `java-a3s-context-collector` |
 
-General rule: strip `-enterprise` suffix, prepend `sonar-`. Exceptions:
+General rule: strip `-enterprise` suffix, then prepend `sonar-` when `sonar-prefix` is `true` (the default). Exceptions:
 - `dotnet-enterprise` maps to `sonar-dotnet` (covers both `csharp-enterprise` and `vbnet-enterprise` via aliases).
-- `java-a3s-context-collector` keeps its name as-is — its anchor is **not** prefixed with `sonar-`.
+- Plugins whose anchor is **not** prefixed with `sonar-` (e.g. `java-a3s-context-collector`) must be updated by passing `sonar-prefix: 'false'`.
 
 ## Usage
 

--- a/update-plugins-deployer/README.md
+++ b/update-plugins-deployer/README.md
@@ -28,7 +28,7 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 | `release-version` | The new version to set (e.g. `1.12.0.12345`) | Yes | |
 | `ticket-key` | Jira ticket number. Must start with `SC-`. | Yes | |
 | `plugin-name` | Plugin language key, used for the anchor lookup, PR title, commit and branch name | Yes | |
-| `sonar-prefix` | Whether the anchor key is prefixed with `sonar-` (`true`/`false`) | No | `true` |
+| `set-sonar-prefix` | Whether the anchor key is prefixed with `sonar-` (`true`/`false`) | No | `true` |
 | `secret-name` | Vault secret name granting write access to `sonar-plugins-deployer` | Yes | |
 | `base-branch` | Base branch for the PR | No | `master` |
 | `draft` | Create PR as draft (`true`/`false`) | No | `false` |
@@ -55,9 +55,9 @@ The `secret-name` provided must have `contents: write` and `pull-requests: write
 | `php`, `kotlin`, etc. | `sonar-{plugin-name}` |
 | `java-a3s-context-collector` | `java-a3s-context-collector` |
 
-General rule: strip `-enterprise` suffix, then prepend `sonar-` when `sonar-prefix` is `true` (the default). Exceptions:
+General rule: strip `-enterprise` suffix, then prepend `sonar-` when `set-sonar-prefix` is `true` (the default). Exceptions:
 - `dotnet-enterprise` maps to `sonar-dotnet` (covers both `csharp-enterprise` and `vbnet-enterprise` via aliases).
-- Plugins whose anchor is **not** prefixed with `sonar-` (e.g. `java-a3s-context-collector`) must be updated by passing `sonar-prefix: false`.
+- Plugins whose anchor is **not** prefixed with `sonar-` (e.g. `java-a3s-context-collector`) must be updated by passing `set-sonar-prefix: false`.
 
 ## Usage
 

--- a/update-plugins-deployer/action.yml
+++ b/update-plugins-deployer/action.yml
@@ -12,6 +12,10 @@ inputs:
   plugin-name:
     description: 'The language key of the plugin to update (e.g., java, security). Used for PR title, commit message, and branch name.'
     required: true
+  sonar-prefix:
+    description: 'A boolean value indicating if the plugin name should be prefixed with sonar- in the update.'
+    required: false
+    default: 'true'
   secret-name:
     description: 'Name of the secret to fetch from the vault that has write access to sonar-plugins-deployer.'
     required: true
@@ -78,6 +82,7 @@ runs:
       env:
         PLUGINS_YAML: plugins.yaml
         PLUGIN_NAME: ${{ inputs.plugin-name }}
+        SONAR_PREFIX: ${{ inputs.sonar-prefix }}
         RELEASE_VERSION: ${{ inputs.release-version }}
       run: bash ${{ github.action_path }}/update_plugins_yaml.sh
 

--- a/update-plugins-deployer/action.yml
+++ b/update-plugins-deployer/action.yml
@@ -15,7 +15,7 @@ inputs:
   sonar-prefix:
     description: 'A boolean value indicating if the plugin name should be prefixed with sonar- in the update.'
     required: false
-    default: 'true'
+    default: true
   secret-name:
     description: 'Name of the secret to fetch from the vault that has write access to sonar-plugins-deployer.'
     required: true

--- a/update-plugins-deployer/action.yml
+++ b/update-plugins-deployer/action.yml
@@ -12,7 +12,7 @@ inputs:
   plugin-name:
     description: 'The language key of the plugin to update (e.g., java, security). Used for PR title, commit message, and branch name.'
     required: true
-  sonar-prefix:
+  set-sonar-prefix:
     description: 'A boolean value indicating if the plugin name should be prefixed with sonar- in the update.'
     required: false
     default: true
@@ -82,7 +82,7 @@ runs:
       env:
         PLUGINS_YAML: plugins.yaml
         PLUGIN_NAME: ${{ inputs.plugin-name }}
-        SONAR_PREFIX: ${{ inputs.sonar-prefix }}
+        SET_SONAR_PREFIX: ${{ inputs.set-sonar-prefix }}
         RELEASE_VERSION: ${{ inputs.release-version }}
       run: bash ${{ github.action_path }}/update_plugins_yaml.sh
 

--- a/update-plugins-deployer/test_update_plugins_yaml.sh
+++ b/update-plugins-deployer/test_update_plugins_yaml.sh
@@ -163,10 +163,10 @@ else
 fi
 rm -rf "$T"
 
-# Test: java-a3s-context-collector → anchor not prefixed with sonar-
+# Test: SONAR_PREFIX="false" → anchor not prefixed with sonar-
 T=$(mktemp -d)
 make_plugins_yaml "$T"
-PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java-a3s-context-collector" RELEASE_VERSION="2.0.0.200" \
+PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java-a3s-context-collector" SONAR_PREFIX="false" RELEASE_VERSION="2.0.0.200" \
   bash "$SCRIPT" >/dev/null 2>&1 && actual_a3s=0 || actual_a3s=$?
 if [[ "$actual_a3s" -eq 0 ]]; then
   assert_contains "java-a3s-context-collector anchor updated" "$T/plugins.yaml" "java-a3s-context-collector: &version-java-a3s-context-collector 2.0.0.200"
@@ -174,6 +174,19 @@ if [[ "$actual_a3s" -eq 0 ]]; then
 else
   echo "❌ java-a3s-context-collector update failed (exit $actual_a3s)"
   FAIL=$((FAIL+2))
+fi
+rm -rf "$T"
+
+# Test: SONAR_PREFIX="true" → anchor is prefixed with sonar-
+T=$(mktemp -d)
+make_plugins_yaml "$T"
+PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java" SONAR_PREFIX="true" RELEASE_VERSION="9.1.0.12345" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_prefix=0 || actual_prefix=$?
+if [[ "$actual_prefix" -eq 0 ]]; then
+  assert_contains "SONAR_PREFIX=true prefixes anchor" "$T/plugins.yaml" "sonar-java: &version-sonar-java 9.1.0.12345"
+else
+  echo "❌ SONAR_PREFIX=true update failed (exit $actual_prefix)"
+  FAIL=$((FAIL+1))
 fi
 rm -rf "$T"
 

--- a/update-plugins-deployer/test_update_plugins_yaml.sh
+++ b/update-plugins-deployer/test_update_plugins_yaml.sh
@@ -69,6 +69,7 @@ versions:
   sonar-text: &version-sonar-text 2.43.0.11106
   sonar-python: &version-sonar-python 5.21.0.32726
   sonar-php: &version-sonar-php 3.56.0.15870
+  java-a3s-context-collector: &version-java-a3s-context-collector 1.0.0.100
 
 plugins:
   - key: sonar-java
@@ -100,6 +101,9 @@ plugins:
 
   - key: sonar-php
     version: *version-sonar-php
+
+  - key: java-a3s-context-collector
+    version: *version-java-a3s-context-collector
 EOF
 }
 
@@ -156,6 +160,20 @@ if [[ "$actual_sec" -eq 0 ]]; then
 else
   echo "❌ security update failed (exit $actual_sec)"
   FAIL=$((FAIL+1))
+fi
+rm -rf "$T"
+
+# Test: java-a3s-context-collector → anchor not prefixed with sonar-
+T=$(mktemp -d)
+make_plugins_yaml "$T"
+PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java-a3s-context-collector" RELEASE_VERSION="2.0.0.200" \
+  bash "$SCRIPT" >/dev/null 2>&1 && actual_a3s=0 || actual_a3s=$?
+if [[ "$actual_a3s" -eq 0 ]]; then
+  assert_contains "java-a3s-context-collector anchor updated" "$T/plugins.yaml" "java-a3s-context-collector: &version-java-a3s-context-collector 2.0.0.200"
+  assert_not_contains "java-a3s-context-collector anchor not sonar-prefixed" "$T/plugins.yaml" "sonar-java-a3s-context-collector"
+else
+  echo "❌ java-a3s-context-collector update failed (exit $actual_a3s)"
+  FAIL=$((FAIL+2))
 fi
 rm -rf "$T"
 

--- a/update-plugins-deployer/test_update_plugins_yaml.sh
+++ b/update-plugins-deployer/test_update_plugins_yaml.sh
@@ -163,10 +163,10 @@ else
 fi
 rm -rf "$T"
 
-# Test: SONAR_PREFIX="false" → anchor not prefixed with sonar-
+# Test: SET_SONAR_PREFIX="false" → anchor not prefixed with sonar-
 T=$(mktemp -d)
 make_plugins_yaml "$T"
-PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java-a3s-context-collector" SONAR_PREFIX="false" RELEASE_VERSION="2.0.0.200" \
+PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java-a3s-context-collector" SET_SONAR_PREFIX="false" RELEASE_VERSION="2.0.0.200" \
   bash "$SCRIPT" >/dev/null 2>&1 && actual_a3s=0 || actual_a3s=$?
 if [[ "$actual_a3s" -eq 0 ]]; then
   assert_contains "java-a3s-context-collector anchor updated" "$T/plugins.yaml" "java-a3s-context-collector: &version-java-a3s-context-collector 2.0.0.200"
@@ -177,15 +177,15 @@ else
 fi
 rm -rf "$T"
 
-# Test: SONAR_PREFIX="true" → anchor is prefixed with sonar-
+# Test: SET_SONAR_PREFIX="true" → anchor is prefixed with sonar-
 T=$(mktemp -d)
 make_plugins_yaml "$T"
-PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java" SONAR_PREFIX="true" RELEASE_VERSION="9.1.0.12345" \
+PLUGINS_YAML="$T/plugins.yaml" PLUGIN_ARTIFACTS="" PLUGIN_NAME="java" SET_SONAR_PREFIX="true" RELEASE_VERSION="9.1.0.12345" \
   bash "$SCRIPT" >/dev/null 2>&1 && actual_prefix=0 || actual_prefix=$?
 if [[ "$actual_prefix" -eq 0 ]]; then
-  assert_contains "SONAR_PREFIX=true prefixes anchor" "$T/plugins.yaml" "sonar-java: &version-sonar-java 9.1.0.12345"
+  assert_contains "SET_SONAR_PREFIX=true prefixes anchor" "$T/plugins.yaml" "sonar-java: &version-sonar-java 9.1.0.12345"
 else
-  echo "❌ SONAR_PREFIX=true update failed (exit $actual_prefix)"
+  echo "❌ SET_SONAR_PREFIX=true update failed (exit $actual_prefix)"
   FAIL=$((FAIL+1))
 fi
 rm -rf "$T"

--- a/update-plugins-deployer/update_plugins_yaml.sh
+++ b/update-plugins-deployer/update_plugins_yaml.sh
@@ -5,6 +5,10 @@
 #   PLUGINS_YAML    - path to plugins.yaml
 #   PLUGIN_NAME     - plugin name used to compute the anchor key
 #   RELEASE_VERSION - new version string (e.g. 1.2.3.45678)
+#
+# Environment variables (optional):
+#   SONAR_PREFIX    - "true" (default) prefixes the anchor key with "sonar-";
+#                     any other value leaves the key unprefixed
 
 set -euo pipefail
 
@@ -15,11 +19,15 @@ compute_anchor_key() {
   case "$base" in
     # dotnet special case: csharp and vbnet both map to sonar-dotnet
     csharp|vbnet) base="dotnet" ;;
-    # java-a3s-context-collector exception: the plugin's anchor is not prefixed with sonar-
-    java-a3s-context-collector) echo "$base"; return ;;
     *) ;;
   esac
-  echo "sonar-${base}"
+  # SONAR_PREFIX controls whether the anchor key is prefixed with "sonar-".
+  # Some plugins (e.g. java-a3s-context-collector) use an unprefixed anchor.
+  if [[ "$SONAR_PREFIX" == "true" ]]; then
+    echo "sonar-${base}"
+  else
+    echo "$base"
+  fi
 }
 
 update_anchor() {
@@ -45,6 +53,7 @@ update_anchor() {
 PLUGINS_YAML="${PLUGINS_YAML:-plugins.yaml}"
 RELEASE_VERSION="${RELEASE_VERSION:?RELEASE_VERSION is required}"
 PLUGIN_NAME="${PLUGIN_NAME:?PLUGIN_NAME is required}"
+SONAR_PREFIX="${SONAR_PREFIX:-true}"
 
 # The anchor key is always derived from PLUGIN_NAME — one anchor per plugin family
 # (e.g. sonar-security covers all security frontends via aliases).

--- a/update-plugins-deployer/update_plugins_yaml.sh
+++ b/update-plugins-deployer/update_plugins_yaml.sh
@@ -12,9 +12,11 @@ compute_anchor_key() {
   local artifact="$1"
   # Strip -enterprise suffix
   local base="${artifact%-enterprise}"
-  # dotnet special case: csharp and vbnet both map to sonar-dotnet
   case "$base" in
+    # dotnet special case: csharp and vbnet both map to sonar-dotnet
     csharp|vbnet) base="dotnet" ;;
+    # java-a3s-context-collector exception: the plugin's anchor is not prefixed with sonar-
+    java-a3s-context-collector) echo "$base"; return ;;
     *) ;;
   esac
   echo "sonar-${base}"

--- a/update-plugins-deployer/update_plugins_yaml.sh
+++ b/update-plugins-deployer/update_plugins_yaml.sh
@@ -7,8 +7,8 @@
 #   RELEASE_VERSION - new version string (e.g. 1.2.3.45678)
 #
 # Environment variables (optional):
-#   SONAR_PREFIX    - "true" (default) prefixes the anchor key with "sonar-";
-#                     any other value leaves the key unprefixed
+#   SONAR_PREFIX    - boolean; true (default) prefixes the anchor key with "sonar-",
+#                     false leaves the key unprefixed
 
 set -euo pipefail
 

--- a/update-plugins-deployer/update_plugins_yaml.sh
+++ b/update-plugins-deployer/update_plugins_yaml.sh
@@ -7,8 +7,8 @@
 #   RELEASE_VERSION - new version string (e.g. 1.2.3.45678)
 #
 # Environment variables (optional):
-#   SONAR_PREFIX    - boolean; true (default) prefixes the anchor key with "sonar-",
-#                     false leaves the key unprefixed
+#   SET_SONAR_PREFIX - boolean; true (default) prefixes the anchor key with "sonar-",
+#                      false leaves the key unprefixed
 
 set -euo pipefail
 
@@ -21,9 +21,9 @@ compute_anchor_key() {
     csharp|vbnet) base="dotnet" ;;
     *) ;;
   esac
-  # SONAR_PREFIX controls whether the anchor key is prefixed with "sonar-".
+  # SET_SONAR_PREFIX controls whether the anchor key is prefixed with "sonar-".
   # Some plugins (e.g. java-a3s-context-collector) use an unprefixed anchor.
-  if [[ "$SONAR_PREFIX" == "true" ]]; then
+  if [[ "$SET_SONAR_PREFIX" == "true" ]]; then
     echo "sonar-${base}"
   else
     echo "$base"
@@ -53,7 +53,7 @@ update_anchor() {
 PLUGINS_YAML="${PLUGINS_YAML:-plugins.yaml}"
 RELEASE_VERSION="${RELEASE_VERSION:?RELEASE_VERSION is required}"
 PLUGIN_NAME="${PLUGIN_NAME:?PLUGIN_NAME is required}"
-SONAR_PREFIX="${SONAR_PREFIX:-true}"
+SET_SONAR_PREFIX="${SET_SONAR_PREFIX:-true}"
 
 # The anchor key is always derived from PLUGIN_NAME — one anchor per plugin family
 # (e.g. sonar-security covers all security frontends via aliases).


### PR DESCRIPTION
----
## Summary by Gitar

- **Added configuration parameter:**
  - Added `sonar-prefix` input to `update-plugins-deployer` to allow disabling the default `sonar-` prefix for anchor keys.
- **Updated logic:**
  - Modified `update_plugins_yaml.sh` to conditionally prepend `sonar-` to the anchor key based on the `SONAR_PREFIX` variable.
- **Workflow & Documentation:**
  - Updated `automated-release.yml` and project documentation to support and document the new `sonar-prefix` input.
- **Testing:**
  - Added automated tests in `test_update_plugins_yaml.sh` to verify both prefixed and non-prefixed anchor key generation.

<sub>This will update automatically on new commits.</sub>