### PR TITLE
GHA-374 Make SQAA Integration PR auto assign reviewer to github actor

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -46,7 +46,7 @@ on:
         type: string
         default: "master"
       sqaa-reviewers:
-        description: "Comma-separated list of GitHub usernames to request a review on the SQAA pull request"
+        description: "Comma-separated list of GitHub usernames to request a review on the SQAA pull request. Defaults to the release actor."
         required: false
         type: string
       use-jira-sandbox:
@@ -963,7 +963,7 @@ jobs:
           plugin-artifacts: ${{ inputs.plugin-artifacts-sqaa }}
           base-branch: ${{ inputs.sqaa-base-branch }}
           draft: ${{ inputs.is-draft-release }}
-          reviewers: ${{ inputs.sqaa-reviewers }}
+          reviewers: ${{ inputs.sqaa-reviewers != '' && inputs.sqaa-reviewers || github.actor }}
 
       - name: Summary
         if: ${{ inputs.verbose }}

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -47,7 +47,7 @@ This workflow composes several actions from this repository:
 | `plugin-artifacts-sqc`       | Artifact identifier(s) for SQC; falls back to `plugin-name`                                                     | No       | -            |
 | `plugin-artifacts-sqaa`      | Artifact identifier(s) for SQAA; falls back to `plugin-name`                                                    | No       | -            |
 | `sqaa-base-branch`           | Base branch for the SQAA pull request                                                                           | No       | `master`     |
-| `sqaa-reviewers`             | Comma-separated list of GitHub usernames to request a review on the SQAA pull request                           | No       | -            |
+| `sqaa-reviewers`             | Comma-separated list of GitHub usernames to request a review on the SQAA pull request. Defaults to the release actor (`github.actor`). | No       | `github.actor` |
 | `use-jira-sandbox`           | Use Jira sandbox                                                                                                | No       | `true`       |
 | `is-draft-release`           | Create the GitHub release as a draft                                                                            | No       | `true`       |
 | `pm-email`                   | Product manager email to assign the release ticket after technical release                                      | Yes      | -            |


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Maintenance ticket in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Maintenance ticket in Jira without a parent 
-->

----
## Summary by Gitar

- **Workflow configuration:**
  - Update `sqaa-reviewers` input to default to the `${{ github.actor }}` if no reviewers are provided.
  - Modify `automated-release.yml` to pass the release actor as the default reviewer to the SQAA job.
- **Documentation:**
  - Update `AUTOMATED_RELEASE.md` to reflect that `sqaa-reviewers` now defaults to the release actor.

<sub>This will update automatically on new commits.</sub>