### PR TITLE
GHA-353 Remove sonarcloud-core logic from update-analyzer action

### DIFF
--- a/.github/workflows/test-update-analyzer.yml
+++ b/.github/workflows/test-update-analyzer.yml
@@ -92,7 +92,7 @@ jobs:
           secret-name: "test-secret"
         continue-on-error: true
 
-      - name: Test Valid SC Ticket
+      - name: Test SC Ticket Now Rejected
         id: test-sc-ticket
         uses: ./update-analyzer
         with:
@@ -101,6 +101,17 @@ jobs:
           plugin-name: "test"
           secret-name: "test-secret"
         continue-on-error: true
+
+      - name: Verify SC Ticket Rejected
+        if: steps.test-sc-ticket.outcome == 'success'
+        run: |
+          echo "✗ Action should have failed for SC- ticket (SQC support removed)"
+          exit 1
+
+      - name: Confirm SC Ticket Rejected
+        if: steps.test-sc-ticket.outcome == 'failure'
+        run: |
+          echo "✓ Action correctly rejected SC- ticket"
 
       - name: Test Plugin Artifacts Parameter
         id: test-plugin-artifacts

--- a/update-analyzer/README.md
+++ b/update-analyzer/README.md
@@ -1,14 +1,13 @@
 # Update Analyzer Action
 
-This GitHub Action automates the process of updating an analyzer's version within SonarQube or SonarCloud. It checks out the respective product repository, modifies the `build.gradle` file with the new version, and creates a pull request with the changes.
+This GitHub Action automates the process of updating an analyzer's version within SonarQube. It checks out the `sonar-enterprise` repository, modifies the `build.gradle` file with the new version, and creates a pull request with the changes.
 
 ## Description
 
 The action updates analyzer versions by:
-1. Determining the target repository based on the ticket prefix (`SONAR-` for SonarQube or `SC-` for SonarCloud)
-2. Checking out the appropriate product repository (`sonar-enterprise` or `sonarcloud-core`)
-3. Updating the analyzer version in the build.gradle file using sed commands
-4. Creating a pull request with the changes using the specified GitHub token from Vault
+1. Checking out the `sonar-enterprise` repository
+2. Updating the analyzer version in the build.gradle file using sed commands
+3. Creating a pull request with the changes using the specified GitHub token from Vault
 
 ## Prerequisites
 
@@ -31,7 +30,7 @@ This action depends on:
 | Input               | Description                                                                                                                                                                                                                                                           | Required | Default  |
 |---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|----------|
 | `release-version`   | The new version to set for the analyzer (e.g., `1.12.0.12345`).                                                                                                                                                                                                       | `true`   |          |
-| `ticket-key`        | The Jira ticket number. Must start with `SONAR-` (for SonarQube) or `SC-` (for SonarCloud).                                                                                                                                                                           | `true`   |          |
+| `ticket-key`        | The Jira ticket number. Must start with `SONAR-`.                                                                                                                                                                                                                     | `true`   |          |
 | `plugin-name`       | The language key of the plugin to update. It will always be used as a part of the PR title and commit message. It can be used to match the artifact in the build script (i.e. it should be the `X` in `sonar-X-plugin`), unless `plugin-artifacts` input is provided. | `true`   |          |
 | `secret-name`       | Name of the secret for GitHub token to fetch from the vault that has permissions to create pull requests in the target Github repository.                                                                                                                             | `true`   |          |
 | `plugin-artifacts`  | Comma-separated list of plugin artifact names (any `X` in `sonar-X-plugin`) that will be used instead of `plugin-name` when provided.                                                                                                                                 | `false`  |          |
@@ -80,7 +79,7 @@ This action depends on:
   uses: SonarSource/release-github-actions/update-analyzer@v1
   with:
     release-version: '1.12.0.12345'
-    ticket-key: 'SC-67890'
+    ticket-key: 'SONAR-67890'
     plugin-name: 'java'
     secret-name: 'sonar-java-release-automation'
     base-branch: 'develop'
@@ -105,7 +104,7 @@ This action depends on:
 
 The action uses a composite action that:
 - Uses the SonarSource Vault action wrapper to securely retrieve GitHub tokens
-- Determines the target repository based on ticket prefix validation
+- Validates the ticket prefix
 - Uses sparse checkout for efficient repository cloning (only the build.gradle file)
 - Updates analyzer versions using sed pattern matching for `sonar-X-plugin` artifacts
 - Creates pull requests with standardized naming conventions and commit messages
@@ -114,7 +113,7 @@ The action uses a composite action that:
 ## Error Handling
 
 The action will fail with a non-zero exit code if:
-- The ticket format is invalid (doesn't start with `SONAR-` or `SC-`)
+- The ticket format is invalid (doesn't start with `SONAR-`)
 - The Vault token retrieval fails
 - The target repository checkout fails
 - The build.gradle file modification fails
@@ -122,7 +121,7 @@ The action will fail with a non-zero exit code if:
 
 ## Notes
 
-- This action specifically targets SonarSource product repositories (`sonar-enterprise` and `sonarcloud-core`)
+- This action specifically targets the `sonar-enterprise` repository
 - The action uses sparse checkout to minimize data transfer and processing time
 - Branch naming follows the pattern: `{plugin-name}/update-analyzer-{release-version}`
 - Commit messages and PR titles follow standardized formats for consistency

--- a/update-analyzer/action.yml
+++ b/update-analyzer/action.yml
@@ -1,5 +1,5 @@
 name: 'Update Analyzer'
-description: 'Updates the version of a specified analyzer in SonarQube or SonarCloud and creates a pull request.'
+description: 'Updates the version of a specified analyzer in SonarQube and creates a pull request.'
 author: 'SonarSource'
 
 inputs:
@@ -7,7 +7,7 @@ inputs:
     description: 'The new version to set for the analyzer (e.g., 1.12.0.12345).'
     required: true
   ticket-key:
-    description: 'The Jira ticket number (e.g., SONAR-12345 or SC-12345). This determines the target product.'
+    description: 'The Jira ticket number (e.g., SONAR-12345).'
     required: true
   plugin-name:
     description: 'The language key of the plugin to update (e.g., architecture, java, csharp).'
@@ -58,11 +58,8 @@ runs:
         if [[ "$TICKET_KEY" == SONAR-* ]]; then
           echo "PRODUCT_REPOSITORY=sonar-enterprise" >> $GITHUB_ENV
           echo "BUILD_GRADLE_FILE=build.gradle" >> $GITHUB_ENV
-        elif [[ "$TICKET_KEY" == SC-* ]]; then
-          echo "PRODUCT_REPOSITORY=sonarcloud-core" >> $GITHUB_ENV
-          echo "BUILD_GRADLE_FILE=private/edition-sonarcloud/build.gradle" >> $GITHUB_ENV
         else
-          echo "::error::Invalid ticket format. Must start with SONAR- or SC-."
+          echo "::error::Invalid ticket format. Must start with SONAR-."
           exit 1
         fi
 


### PR DESCRIPTION
## Problem

`update-analyzer/action.yml` still branches on `SC-*` ticket keys to target `sonarcloud-core` and its `private/edition-sonarcloud/build.gradle`. That branch is unreachable: SQC integration moved to `sonar-plugins-deployer` in a prior change, and `automated-release.yml`'s `update-analyzers` job now only calls `update-analyzer` with the SQS ticket key — the SQC step calls `update-plugins-deployer` instead. Dead code left in an action that validates its own inputs is misleading to anyone reading the ticket-key description or error message.

## Approach

Favor the smallest diff that fully removes the dead branch and keeps docs/tests truthful to the new behavior.

| Question | Decision |
|---|---|
| Remove `plugin-artifacts-sqc` input from `automated-release.yml` too? | **No** — checked GitHub org-wide; 13 active caller repos (sonar-java, sonar-php, sonar-dotnet-enterprise, etc.) still pass this input to the reusable workflow. Removing it would break their next release run (reusable workflows reject unknown inputs). It belongs to `automated-release.yml`, not `update-analyzer`, and is out of scope here. |
| How to handle the `test-update-analyzer.yml` "Test Valid SC Ticket" step? | Repurposed into "Test SC Ticket Now Rejected" with an explicit pass/fail assertion, mirroring the existing invalid-ticket-format test, instead of silently leaving a step whose name no longer matches its expected outcome. |
| Scope of README updates | Full sync: description, ticket-key row, usage example, Notes, and Error Handling bullets — rather than leaving stale mentions of `sonarcloud-core` as "historical context" that would confuse a future reader. |
| Error message wording | Minimal: `"Invalid ticket format. Must start with SONAR-."` — no added explanation of *why* SC- was removed, consistent with how the branch itself is just deleted without a deprecation comment. |

## Implementation

`update-analyzer/action.yml`: removed the `elif [[ "$TICKET_KEY" == SC-* ]]` branch and its `sonarcloud-core` env vars, updated the error message and `ticket-key`/action descriptions. `update-analyzer/README.md`: dropped all SC-/sonarcloud-core mentions to match. `.github/workflows/test-update-analyzer.yml`: repurposed the SC-ticket test to assert rejection. No new abstractions or dependencies.

## Tests

- Ticket-key validation: `SONAR-*` still accepted (unchanged), `SC-*` now explicitly asserted as rejected (previously just asserted it didn't error, though vault-less CI already masked that).
- Existing `INVALID-123` invalid-format test continues to cover the generic non-SONAR- rejection path.

## Test plan

- [x] YAML syntax validated for `update-analyzer/action.yml` and `.github/workflows/test-update-analyzer.yml` (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `actionlint` run on the test workflow file — clean
- [x] Grepped repo for remaining `SC-`/`sonarcloud-core` references in touched files — only the intentional rejection-test fixture remains
- [x] Confirmed via GitHub code search that no caller repo passes an SC- ticket key to `update-analyzer` anymore (only `update-plugins-deployer` handles SQC now)