### PR TITLE
GHA-377 Add OKF knowledge bundle for the repo

### DIFF
--- a/.okf/actions/bump-version.md
+++ b/.okf/actions/bump-version.md
@@ -1,0 +1,34 @@
+---
+type: GitHub Action
+title: Bump Project Version
+description: Updates the version in Maven and Gradle files across the repository, opening a pull request with the change.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/bump-version
+tags: [action, version, maven, gradle, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Composite action that rewrites the project version (without `-SNAPSHOT`) in Maven or Gradle
+build files, optionally excluding specific modules, and opens a pull request with the change.
+Used as the `bump-version` step in [automated-release](/workflows/automated-release.md) to
+prepare the next development iteration after a release.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `version` | The new version (without `-SNAPSHOT`) | Yes | |
+| `token` | GitHub token for PR creation | No | |
+| `excluded-modules` | Comma-separated modules to exclude | No | |
+| `base-branch` | Base branch for the pull request | No | `master` |
+| `pr-labels` | Comma-separated labels for the pull request | No | |
+| `tool` | Version bumping tool (`maven`, or empty for shell-based) | No | |
+
+| Output | Description |
+|---|---|
+| `pull-request-url` | URL of the created pull request |
+
+# Citations
+
+[1] [bump-version/README.md](/../bump-version/README.md)

--- a/.okf/actions/check-releasability-status.md
+++ b/.okf/actions/check-releasability-status.md
@@ -1,0 +1,35 @@
+---
+type: GitHub Action
+title: Check Releasability Status
+description: Verifies the GitHub commit-status "Releasability" check is successful on a branch before a release proceeds.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/check-releasability-status
+tags: [action, releasability, ci-gate]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Reads the GitHub Statuses API for the target branch, filters for the `Releasability` context,
+and confirms the state is `success` (optionally also checking that the description does not
+contain "failed optional checks").
+
+Standalone, this action historically could read a **stale** commit status. The
+[automated-release workflow](/workflows/automated-release.md) itself does **not** rely on this
+action for its releasability gate — it instead calls `SonarSource/gh-action_releasability@v3`
+directly with the exact commit SHA. See
+[risk: stale releasability status read](/risks/stale-releasability-status.md) for the
+distinction between this standalone action and the orchestrator's own gate.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `github-token` | GitHub token for API calls | No | `${{ github.token }}` |
+| `branch` | Branch to check | No | `master` |
+| `with-optional-checks` | Also check for "failed optional checks" in the description | No | `true` |
+
+Requires `statuses: read` permission on the GitHub token.
+
+# Citations
+
+[1] [check-releasability-status/README.md](/../check-releasability-status/README.md)

--- a/.okf/actions/create-integration-ticket.md
+++ b/.okf/actions/create-integration-ticket.md
@@ -1,0 +1,30 @@
+---
+type: GitHub Action
+title: Create Integration Ticket
+description: Creates a Jira integration ticket with a custom summary and links it to an existing release ticket.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/create-integration-ticket
+tags: [action, jira, integration-ticket]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Python-based action that connects to Jira, validates the release ticket exists, creates a new
+ticket in a target Jira project (e.g. `SLVS`, `SLVSCODE`, `SLE`, `SLI`, `SQS`, `SQC`), sets its
+description, and links it to the release ticket. Used by
+[automated-release](/workflows/automated-release.md) to fan out IDE/CLI integration tickets
+after a release.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `release-ticket-key` | Key of the ticket to link to (e.g. `REL-123`) | Yes | - |
+| `target-jira-project` | Key of the project to create the ticket in | Yes | - |
+
+Uses the shared [Jira integration helpers](/shared/jira-common.md) and Vault-sourced
+credentials.
+
+# Citations
+
+[1] [create-integration-ticket/README.md](/../create-integration-ticket/README.md)

--- a/.okf/actions/create-jira-release-ticket.md
+++ b/.okf/actions/create-jira-release-ticket.md
@@ -1,0 +1,29 @@
+---
+type: GitHub Action
+title: Create Jira Release Ticket
+description: Creates the "Ask for release" ticket in Jira that anchors the rest of the release process.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/create-jira-release-ticket
+tags: [action, jira, release-ticket]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Creates an "Ask for release" ticket in Jira with custom fields populated (short description,
+release notes link, rule-props-changed, etc.), optionally auto-fetching the release version and
+release notes URL, and optionally transitioning it to "Start Progress". This is the first
+Jira-side mutation in [automated-release](/workflows/automated-release.md) — see
+[risk: no idempotency on mutating steps](/risks/no-idempotency.md), since nothing checks whether
+a REL ticket for this version already exists before creating a new one.
+
+# Schema
+
+Depends on [get-release-version](/actions/get-release-version.md) (when version not provided),
+[update-release-ticket-status](/actions/update-release-ticket-status.md) (when starting
+progress), and [get-jira-release-notes](/actions/get-jira-release-notes.md) (when no release
+notes URL is supplied). Uses [shared Jira helpers](/shared/jira-common.md) and Vault-sourced
+credentials.
+
+# Citations
+
+[1] [create-jira-release-ticket/README.md](/../create-jira-release-ticket/README.md)

--- a/.okf/actions/create-jira-version.md
+++ b/.okf/actions/create-jira-version.md
@@ -1,0 +1,29 @@
+---
+type: GitHub Action
+title: Create Jira Version
+description: Creates a new version in a Jira project, optionally auto-determining the next version number.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/create-jira-version
+tags: [action, jira, version]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Connects to Jira and creates a new version in the specified project, either using a provided
+version name or deriving the next one via [get-jira-version](/actions/get-jira-version.md).
+Called as part of releasing the current version and preparing the next one in
+[automated-release](/workflows/automated-release.md) (via
+[release-jira-version](/actions/release-jira-version.md)'s flow). No "already exists" check is
+performed before creation — see [risk: no idempotency on mutating steps](/risks/no-idempotency.md).
+
+# Schema
+
+| Input | Description |
+|---|---|
+| `jira-project-key` | Jira project key (e.g. `SONARIAC`); also settable via `JIRA_PROJECT_KEY` |
+
+Uses [shared Jira helpers](/shared/jira-common.md) and Vault-sourced credentials.
+
+# Citations
+
+[1] [create-jira-version/README.md](/../create-jira-version/README.md)

--- a/.okf/actions/create-pull-request.md
+++ b/.okf/actions/create-pull-request.md
@@ -1,0 +1,39 @@
+---
+type: GitHub Action
+title: Create Pull Request
+description: In-house replacement for peter-evans/create-pull-request using the gh CLI, with vault-based token resolution.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/create-pull-request
+tags: [action, pull-request, github-cli, shared-building-block]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Stages and commits file changes on a new branch, then creates a pull request (or updates an
+existing one) via the `gh` CLI. Supports labels, reviewers, assignees, milestones, and drafts.
+Resolves an authentication token via Vault first, falling back to the provided `token` input.
+
+This is a shared building block reused by several higher-level actions:
+[update-analyzer](/actions/update-analyzer.md),
+[update-plugins-deployer](/actions/update-plugins-deployer.md),
+[update-analysis-as-a-service](/actions/update-analysis-as-a-service.md), and
+[update-rule-metadata](/actions/update-rule-metadata.md).
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `token` | GitHub token (vault token preferred, falls back to this) | No | `${{ github.token }}` |
+| `add-paths` | Comma/newline-separated paths to stage | No | `''` (all changes) |
+| `commit-message` | Commit message | No | `[create-pull-request] automated change` |
+| `committer` | Committer `Name <email>` | No | `github-actions[bot] <...>` |
+| `author` | Author `Name <email>` | No | `${{ github.actor }} <...>` |
+| `signoff` | Add `Signed-off-by` trailer | No | `false` |
+
+Requires the repository to already be checked out, a token with `contents: write` and
+`pull-requests: write`, and (for vault resolution) `id-token: write` plus a vault secret at
+`development/github/token/{REPO_OWNER_NAME_DASH}-release-automation`.
+
+# Citations
+
+[1] [create-pull-request/README.md](/../create-pull-request/README.md)

--- a/.okf/actions/get-jira-release-notes.md
+++ b/.okf/actions/get-jira-release-notes.md
@@ -1,0 +1,25 @@
+---
+type: GitHub Action
+title: Get Jira Release Notes
+description: Fetches Jira issues for a fixVersion and formats them into release notes plus the release notes URL.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/get-jira-release-notes
+tags: [action, jira, release-notes]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Retrieves the version ID for a project/version name, fetches all issues with that `fixVersion`,
+and formats them into categorized release notes (Markdown and Jira wiki markup), alongside the
+Jira release-notes URL. Falls back to [get-jira-version](/actions/get-jira-version.md) when
+neither `jira-version-name` nor `JIRA_VERSION_NAME` is supplied. Used by
+[create-jira-release-ticket](/actions/create-jira-release-ticket.md) and by
+[automated-release](/workflows/automated-release.md) when `release-notes` is left empty.
+
+# Schema
+
+Uses [shared Jira helpers](/shared/jira-common.md) and Vault-sourced credentials.
+
+# Citations
+
+[1] [get-jira-release-notes/README.md](/../get-jira-release-notes/README.md)

--- a/.okf/actions/get-jira-version.md
+++ b/.okf/actions/get-jira-version.md
@@ -1,0 +1,26 @@
+---
+type: GitHub Action
+title: Get Jira Version
+description: Converts a release version (major.minor.patch.build) into Jira's version naming convention.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/get-jira-version
+tags: [action, jira, version]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Takes a release version and derives the Jira-compatible form by keeping only
+major.minor.patch and stripping a trailing `.0`. Depends on
+[get-release-version](/actions/get-release-version.md) to obtain the release version.
+
+# Schema
+
+| Output | Description |
+|---|---|
+| `jira-version-name` | The Jira-formatted version |
+
+Also exported as the `JIRA_VERSION_NAME` environment variable.
+
+# Citations
+
+[1] [get-jira-version/README.md](/../get-jira-version/README.md)

--- a/.okf/actions/get-release-version.md
+++ b/.okf/actions/get-release-version.md
@@ -1,0 +1,33 @@
+---
+type: GitHub Action
+title: Get Release Version
+description: Extracts the release version from the repox commit status on a branch.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/get-release-version
+tags: [action, version, repox]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Calls the GitHub API for the commit status on a branch (default `master`), filters for a
+context starting with `repox`, and extracts the version from the status description via `jq`.
+Every downstream job in [automated-release](/workflows/automated-release.md) keys off this
+output, yet the parse is inline shell with no unit test — see
+[risk: fragile version parsing](/risks/fragile-version-parsing.md).
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `github-token` | GitHub token for API calls | No | `${{ github.token }}` |
+| `branch` | Branch to read the version from | No | `master` |
+
+| Output | Description |
+|---|---|
+| `release-version` | The extracted release version |
+
+Also exported as the `RELEASE_VERSION` environment variable. Requires `statuses: read`.
+
+# Citations
+
+[1] [get-release-version/README.md](/../get-release-version/README.md)

--- a/.okf/actions/index.md
+++ b/.okf/actions/index.md
@@ -1,0 +1,24 @@
+# Actions
+
+* [bump-version](bump-version.md) - updates the version in Maven/Gradle files, opens a PR.
+* [check-releasability-status](check-releasability-status.md) - verifies the Releasability commit status on a branch.
+* [create-integration-ticket](create-integration-ticket.md) - creates a Jira integration ticket linked to a release ticket.
+* [create-jira-release-ticket](create-jira-release-ticket.md) - creates the "Ask for release" ticket in Jira.
+* [create-jira-version](create-jira-version.md) - creates a new version in a Jira project.
+* [create-pull-request](create-pull-request.md) - shared PR-creation building block using the `gh` CLI.
+* [get-jira-release-notes](get-jira-release-notes.md) - fetches and formats Jira release notes.
+* [get-jira-version](get-jira-version.md) - converts a release version to Jira's version naming convention.
+* [get-release-version](get-release-version.md) - extracts the release version from the repox commit status.
+* [lock-branch](lock-branch.md) - locks/unlocks a branch via branch protection rules.
+* [notify-failure](notify-failure.md) - rich Slack failure notification with root-cause extraction.
+* [notify-slack](notify-slack.md) - minimal Slack failure notification.
+* [publish-github-release](publish-github-release.md) - creates a GitHub release and triggers the downstream release workflow.
+* [release-jira-version](release-jira-version.md) - marks a Jira version as released.
+* [resolve-ktlo-epic](resolve-ktlo-epic.md) - finds the current KTLO epic in a Jira project.
+* [slack-message](slack-message.md) - sends a markdown message to Slack.
+* [sonar-update-center-release](sonar-update-center-release.md) - adds a release entry to sonar-update-center-properties.
+* [update-analysis-as-a-service](update-analysis-as-a-service.md) - updates analyzer versions in sonar-analysis-as-a-service.
+* [update-analyzer](update-analyzer.md) - updates an analyzer version in sonar-enterprise.
+* [update-plugins-deployer](update-plugins-deployer.md) - updates a plugin version anchor in sonar-plugins-deployer.
+* [update-release-ticket-status](update-release-ticket-status.md) - transitions a release ticket's status.
+* [update-rule-metadata](update-rule-metadata.md) - refreshes rule metadata via the rule-api tooling.

--- a/.okf/actions/lock-branch.md
+++ b/.okf/actions/lock-branch.md
@@ -1,0 +1,42 @@
+---
+type: GitHub Action
+title: Lock Branch
+description: Locks or unlocks a branch by toggling lock_branch in its branch protection rules.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/lock-branch
+tags: [action, branch-protection, freeze]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Freezes (locks) or unfreezes (unlocks) a branch by modifying `lock_branch` in its branch
+protection rules, with an optional Slack notification. This is the mechanism behind the
+`freeze-branch` input of [automated-release](/workflows/automated-release.md). Requires branch
+protection to be enabled (or creates it with minimal settings) and a token with
+`administration:write`.
+
+Its underlying `lock_branch.py` preserves `required_status_checks.contexts` on every
+freeze/unfreeze PUT, which is why the [release-lock](/workflows/release-lock.md) required check
+survives freeze/unfreeze cycles once registered. See
+[risk: always() unfreeze on failure](/risks/unfreeze-on-failure.md) for how the orchestrator
+uses this action in a way that can leave a broken release with an open branch.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `branch` | Branch to lock/unlock | Yes | - |
+| `freeze` | `true` to lock, `false` to unlock | Yes | - |
+| `slack-channel` | Slack channel to notify | No | - |
+| `github-token` | Token with admin permissions | No | From Vault |
+| `slack-token` | Slack token | No | From Vault |
+
+| Output | Description |
+|---|---|
+| `previous-state` | Previous lock state |
+| `current-state` | Current lock state |
+| `branch` | Branch that was modified |
+
+# Citations
+
+[1] [lock-branch/README.md](/../lock-branch/README.md)

--- a/.okf/actions/notify-failure.md
+++ b/.okf/actions/notify-failure.md
@@ -1,0 +1,20 @@
+---
+type: GitHub Action
+title: Notify Failure
+description: Sends a rich Slack failure notification assembled automatically from GitHub context, commit info, and job logs.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/notify-failure
+tags: [action, slack, ci, observability]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+On CI failure, fetches commit info and job logs via the GitHub API and posts a structured Slack
+message: repo/branch/workflow, failed job names, run attempt, last commit, a root-cause line
+extracted from job logs, a Develocity build-scan link if present, and links to the run. All
+sections included by default; individually excludable. Depends on
+[vault-action-wrapper](https://github.com/SonarSource/vault-action-wrapper) for the Slack token.
+
+# Citations
+
+[1] [notify-failure/README.md](/../notify-failure/README.md)

--- a/.okf/actions/notify-slack.md
+++ b/.okf/actions/notify-slack.md
@@ -1,0 +1,19 @@
+---
+type: GitHub Action
+title: Notify Slack on Failure
+description: Sends a Slack notification when a job fails.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/notify-slack
+tags: [action, slack, ci]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Minimal action that posts a job-failure notification to Slack. Lighter-weight than
+[notify-failure](/actions/notify-failure.md), which assembles a richer message with root-cause
+extraction. Depends on
+[vault-action-wrapper](https://github.com/SonarSource/vault-action-wrapper) for the Slack token.
+
+# Citations
+
+[1] [notify-slack/README.md](/../notify-slack/README.md)

--- a/.okf/actions/publish-github-release.md
+++ b/.okf/actions/publish-github-release.md
@@ -1,0 +1,28 @@
+---
+type: GitHub Action
+title: Publish GitHub Release
+description: Creates a GitHub Release from Jira release notes and triggers/monitors the caller's downstream release workflow.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/publish-github-release
+tags: [action, github-release, gh-action_release]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Validates a release version is available, creates a GitHub release (optionally attaching Repox
+artifacts), then triggers the caller repository's `gh-action_release` workflow and waits for it
+to complete. Auto-detects whether the caller uses `gh-action_release` v6 or v7 by inspecting the
+workflow file (tag ref, SHA+comment, or a `releaseId` input signals v6; otherwise v7 is assumed).
+
+- **v6**: creates a draft, attaches artifacts, publishes when `draft=false`; passes `releaseId`
+  downstream.
+- **v7 (default)**: draft-first flow — always drafts, passes only `version`/`dryRun`; v7 itself
+  handles draft-to-published promotion.
+
+This action **is** partially idempotent — it queries existing releases by title and reuses an
+existing draft rather than colliding — but only for the draft case; a re-run after a *published*
+release is unguarded. See [risk: no idempotency on mutating steps](/risks/no-idempotency.md).
+
+# Citations
+
+[1] [publish-github-release/README.md](/../publish-github-release/README.md)

--- a/.okf/actions/release-jira-version.md
+++ b/.okf/actions/release-jira-version.md
@@ -1,0 +1,22 @@
+---
+type: GitHub Action
+title: Release Jira Version
+description: Marks a Jira version as released with today's release date.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/release-jira-version
+tags: [action, jira, version, release]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Finds the Jira version matching `jira-version-name` in the given project and marks it released,
+setting the release date to today. Falls back to
+[get-jira-version](/actions/get-jira-version.md) for auto-determining the version name. Used in
+[automated-release](/workflows/automated-release.md) right after
+[publish-github-release](/actions/publish-github-release.md) and before
+[create-jira-version](/actions/create-jira-version.md) creates the next version. Has no
+"already released?" check — see [risk: no idempotency on mutating steps](/risks/no-idempotency.md).
+
+# Citations
+
+[1] [release-jira-version/README.md](/../release-jira-version/README.md)

--- a/.okf/actions/resolve-ktlo-epic.md
+++ b/.okf/actions/resolve-ktlo-epic.md
@@ -1,0 +1,32 @@
+---
+type: GitHub Action
+title: Resolve KTLO Epic
+description: Finds the current Keep-The-Lights-On epic in a Jira project via a regex match on in-progress epic summaries.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/resolve-ktlo-epic
+tags: [action, jira, ktlo]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Queries Jira for in-progress epics whose summary matches a configurable regex (default `KTLO`).
+Zero matches → logs a warning and outputs an empty string without failing (callers proceed
+without a parent epic). Multiple matches → picks the first and warns. Used by
+[automated-release](/workflows/automated-release.md) via `ktlo-jira-project-key` /
+`ktlo-epic-name-pattern` to attach integration tickets to the active KTLO epic.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `jira-project` | Jira project key to search | Yes | - |
+| `epic-name-pattern` | Regex matched case-insensitively against epic summaries | No | `KTLO` |
+| `use-jira-sandbox` | Use sandbox instead of production | No | - |
+
+| Output | Description |
+|---|---|
+| `epic-key` | Matching epic key, or empty string if none found |
+
+# Citations
+
+[1] [resolve-ktlo-epic/README.md](/../resolve-ktlo-epic/README.md)

--- a/.okf/actions/slack-message.md
+++ b/.okf/actions/slack-message.md
@@ -1,0 +1,27 @@
+---
+type: GitHub Action
+title: Send Slack Message
+description: Sends a caller-provided markdown message to a Slack channel.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/slack-message
+tags: [action, slack]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Posts a markdown message (converted to Slack mrkdwn) to a channel. Unlike
+`rtCamp/action-slack-notify`, uses `slackapi/slack-github-action` and needs no Docker. The
+caller builds the message string; this action only delivers it. Depends on
+`LoveToKnow/slackify-markdown-action` for markdown conversion and
+`slackapi/slack-github-action` for `chat.postMessage`.
+
+# Schema
+
+| Input | Description | Required |
+|---|---|---|
+| `channel` | Slack channel (without `#`) | Yes |
+| `message-markdown` | Message in markdown format | Yes |
+
+# Citations
+
+[1] [slack-message/README.md](/../slack-message/README.md)

--- a/.okf/actions/sonar-update-center-release.md
+++ b/.okf/actions/sonar-update-center-release.md
@@ -1,0 +1,29 @@
+---
+type: GitHub Action
+title: Sonar Update Center Release
+description: Opens a PR in sonar-update-center-properties adding a new release entry to a .properties file.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/sonar-update-center-release
+tags: [action, update-center, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Runs an in-place Python update (`update.py`) of a target `.properties` file in
+`sonar-update-center-properties`, adding a new version/date/description/changelog-URL entry,
+then opens a pull request. Requires the `release-automation` Vault token to include
+`contents: write` and `pull-requests: write` for that repository.
+
+# Schema
+
+| Input | Description | Required |
+|---|---|---|
+| `file` | The `.properties` file to update | Yes |
+| `version` | New version string (e.g. `5.5.0.6356`) | Yes |
+| `description` | Description field of the new entry | Yes |
+| `date` | Date field; defaults to today | No |
+| `changelog-url` | Changelog URL field | Yes |
+
+# Citations
+
+[1] [sonar-update-center-release/README.md](/../sonar-update-center-release/README.md)

--- a/.okf/actions/update-analysis-as-a-service.md
+++ b/.okf/actions/update-analysis-as-a-service.md
@@ -1,0 +1,33 @@
+---
+type: GitHub Action
+title: Update Analysis as a Service
+description: Updates analyzer versions in sonar-analysis-as-a-service's Gradle version catalog and opens a PR.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/update-analysis-as-a-service
+tags: [action, sqaa, gradle, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Checks out `SonarSource/sonar-analysis-as-a-service`, resolves version keys from `plugin-name`
+or `plugin-artifacts`, updates matching entries in `gradle/sonar-plugins.versions.toml` (the
+`sonarAnalyzers` catalog, distinct from the default `libs` catalog), and opens a PR via
+[create-pull-request](/actions/create-pull-request.md). That catalog file is deliberately left
+ownerless in CODEOWNERS so analyzer squads can self-merge their own bumps. Corresponds to the
+`sqaa-integration` input of [automated-release](/workflows/automated-release.md), which only
+runs when `sqc-integration` is also true, and is skipped silently if the analyzer isn't yet
+onboarded to SQAA.
+
+# Schema
+
+| Input | Description | Required |
+|---|---|---|
+| `release-version` | New analyzer version (e.g. `1.12.0.12345`) | Yes |
+| `plugin-name` | Language key used to resolve version entries | see README |
+
+Requires `contents: write` and `pull-requests: write` on `sonar-analysis-as-a-service` for the
+`secret-name` Vault token.
+
+# Citations
+
+[1] [update-analysis-as-a-service/README.md](/../update-analysis-as-a-service/README.md)

--- a/.okf/actions/update-analyzer.md
+++ b/.okf/actions/update-analyzer.md
@@ -1,0 +1,29 @@
+---
+type: GitHub Action
+title: Update Analyzer
+description: Bumps an analyzer version in sonar-enterprise's build.gradle and opens a PR.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/update-analyzer
+tags: [action, sqs, sonar-enterprise, gradle, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Checks out `sonar-enterprise`, updates the analyzer version in `build.gradle` via `sed`, and
+opens a PR through [create-pull-request](/actions/create-pull-request.md). Corresponds to the
+`sqs-integration` fan-out of [automated-release](/workflows/automated-release.md). Logic that
+previously called into `sonarcloud-core` was removed (see `d09b37a`).
+
+Inline shell (~121 lines) with no unit test — see
+[risk: bash actions with real logic are untested](/risks/untested-inline-shell.md).
+
+# Schema
+
+Requires `contents: write` and `pull-requests: write` on `sonar-enterprise` for the
+`secret-name` Vault token. Depends on
+[vault-action-wrapper@v3](https://github.com/SonarSource/vault-action-wrapper),
+`actions/checkout@v4`, and [create-pull-request](/actions/create-pull-request.md).
+
+# Citations
+
+[1] [update-analyzer/README.md](/../update-analyzer/README.md)

--- a/.okf/actions/update-plugins-deployer.md
+++ b/.okf/actions/update-plugins-deployer.md
@@ -1,0 +1,32 @@
+---
+type: GitHub Action
+title: Update Plugins Deployer
+description: Bumps a plugin version anchor in sonar-plugins-deployer's plugins.yaml and opens a PR.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/update-plugins-deployer
+tags: [action, sqc, sonar-plugins-deployer, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Validates the ticket key starts with `SC-`, checks out `plugins.yaml` from
+`sonar-plugins-deployer`, computes the anchor key from `plugin-name` (strips `-enterprise`
+suffix; maps `csharp`/`vbnet` → `dotnet`; the `sonar-` prefix in anchor keys is optional per
+`8b28303`), updates the version anchor in the `versions:` block (all `plugins:` aliases pick up
+the change automatically), and opens a PR via
+[create-pull-request](/actions/create-pull-request.md). Corresponds to the `sqc-integration`
+fan-out of [automated-release](/workflows/automated-release.md).
+
+# Schema
+
+| Input | Description | Required |
+|---|---|---|
+| `release-version` | New version (e.g. `1.12.0.12345`) | Yes |
+| `ticket-key` | Jira ticket key, must start with `SC-` | Yes |
+
+Requires `contents: write` and `pull-requests: write` on `sonar-plugins-deployer` for the
+`secret-name` Vault token.
+
+# Citations
+
+[1] [update-plugins-deployer/README.md](/../update-plugins-deployer/README.md)

--- a/.okf/actions/update-release-ticket-status.md
+++ b/.okf/actions/update-release-ticket-status.md
@@ -1,0 +1,30 @@
+---
+type: GitHub Action
+title: Update Release Ticket Status
+description: Transitions an "Ask for release" Jira ticket to a new status and optionally reassigns it.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/update-release-ticket-status
+tags: [action, jira, release-ticket]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Fetches the release ticket, optionally reassigns it, and transitions it to the target status
+(`Start Progress` or `Technical Release Done`). Used by
+[create-jira-release-ticket](/actions/create-jira-release-ticket.md) (to start progress) and by
+[automated-release](/workflows/automated-release.md) to close out the ticket lifecycle, assigning
+it to `pm-email` after the technical release.
+
+# Schema
+
+| Input | Description | Required |
+|---|---|---|
+| `release-ticket-key` | Jira ticket key (e.g. `REL-1234`) | Yes |
+| `status` | Target status; must be a valid transition | Yes |
+| `assignee` | Email of the user to assign | No |
+
+Uses [shared Jira helpers](/shared/jira-common.md) and Vault-sourced credentials.
+
+# Citations
+
+[1] [update-release-ticket-status/README.md](/../update-release-ticket-status/README.md)

--- a/.okf/actions/update-rule-metadata.md
+++ b/.okf/actions/update-rule-metadata.md
@@ -1,0 +1,31 @@
+---
+type: GitHub Action
+title: Update Rule Metadata
+description: Runs the rule-api tooling across all languages to refresh rule metadata and opens a PR with the diff.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/update-rule-metadata
+tags: [action, rule-api, rspec, pull-request]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Downloads the specified `rule-api` JAR version, discovers directories containing
+`sonarpedia.json` (or uses explicitly specified files), runs `rule-api update` in each, and — if
+anything changed — opens a PR via [create-pull-request](/actions/create-pull-request.md) plus a
+per-language summary. A *skipped* run of this job has previously caused downstream jobs
+(including unfreeze) to be silently skipped too — see
+[risk: success()/skipped transitive gate](/risks/orchestrator-untested.md).
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `rule-api-version` | Version of the rule-api tooling | see README | |
+
+Requires Java 17, Git, and
+[vault-action-wrapper](https://github.com/SonarSource/vault-action-wrapper) for Artifactory
+credentials and GitHub token.
+
+# Citations
+
+[1] [update-rule-metadata/README.md](/../update-rule-metadata/README.md)

--- a/.okf/decisions/architecture-review-2026-07.md
+++ b/.okf/decisions/architecture-review-2026-07.md
@@ -1,0 +1,84 @@
+---
+type: Decision
+title: Automated Release Workflow — Architecture Review (2026-07-14)
+description: Code review of the analyzer release orchestrator identifying it as an un-idempotent, untested-at-the-orchestrator-level distributed transaction.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/docs/ARCHITECTURE_REVIEW.md
+tags: [decision, review, reliability, testability]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Overview
+
+Scope: [automated-release](/workflows/automated-release.md) and the ~20 composite actions it
+orchestrates. [ide-automated-release](/workflows/ide-automated-release.md) and
+[abd-automated-release](/workflows/abd-automated-release.md) are explicitly out of scope.
+Method: code read of the orchestrator + actions, cross-checked with internal
+incident/ticket/Slack mining and external best-practice research, from both a "release DRI" and
+a "workflow maintainer" persona.
+
+# TL;DR
+
+The workflow works and is in daily use, but is a **multi-system distributed transaction with no
+idempotency and no recovery model**, tested only by per-action unit tests with **no test of the
+orchestrator itself**. Two structural facts explain almost every finding below:
+
+1. No mutating step is idempotent — see [risk: no idempotency](/risks/no-idempotency.md).
+2. The orchestrator's control flow (`needs:` + `if:` + output plumbing) is untested — see
+   [risk: orchestrator has no test](/risks/orchestrator-untested.md).
+
+# Top 5 highest-leverage fixes
+
+| Priority | Fix | Addresses |
+|---|---|---|
+| P0 | Idempotency guards + per-failure-point recovery runbook | Half-done releases, duplicate REL tickets, MI1162-class stalls |
+| P0 | Orchestrator dry-run mode exercising the full DAG in CI | Untested wiring, GHA-226/227-class `if:`/`success()` footguns |
+| P1 | inputs/outputs contract test (golden-file snapshot) per action | Silent `@v1` breaking changes |
+| P1 | Fix freeze/unfreeze recovery model — don't `always()` unfreeze after a post-publish failure | MI1162, GHA-227, "branch still frozen" pain |
+| P1 | Delete the dead `set-release-lock`/`clear-release-lock` stub jobs and their aspirational comments | Confusion, misrepresented guarantees (GHA-355 scar) |
+
+# Incidents mapped to design gaps
+
+| Incident / ticket | What happened | Root design gap |
+|---|---|---|
+| MI1162 (RCA, MIM-376) | Release tooling delayed a customer-facing regression fix; recovery needed a manually-built master-unfreeze workflow | No safe recovery path; freeze can be left stuck |
+| GHA-226 / GHA-227 | A skipped [update-rule-metadata](/actions/update-rule-metadata.md) silently skipped downstream jobs incl. unfreeze — master left frozen | Untested `if:`/`needs:` control flow; `success()` transitive-skip footgun |
+| GHA-355 / June 29 | release-lock rollout broke releases across multiple repos; ripped out | Token model; per-repo fan-out amplifies blast radius; no pre-prod integration test |
+| GHA-351 (#170) | A non-existent PyPI version broke every action at install time | No lockfile/verified pin; no `pip install` smoke test |
+| check-releasability false-green / over-strict-fail | Reported green on stale Jira-optional failure; later failed on stale optional checks | Historical stale-status read — note: the orchestrator itself now uses the exact commit SHA, so this is ecosystem context, not a defect in `automated-release.yml` |
+| gh-action_release v7 / `releaseId` | Automation lagged GitHub's release-immutability migration | Tight coupling to an external action's input contract, no compatibility test |
+
+# All findings
+
+See individual [risk](/risks/index.md) concepts for full detail:
+[no idempotency](/risks/no-idempotency.md),
+[always() unfreeze on failure](/risks/unfreeze-on-failure.md),
+[no concurrency guard](/risks/no-concurrency-guard.md),
+[fragile version parsing](/risks/fragile-version-parsing.md),
+[orchestrator has no test](/risks/orchestrator-untested.md),
+[bash actions with real logic are untested](/risks/untested-inline-shell.md),
+[no inputs/outputs contract test](/risks/no-contract-test.md),
+[input sprawl with undocumented invalid combinations](/risks/input-sprawl.md),
+[SonarSource-specific hardcoding in a "reusable" workflow](/risks/hardcoded-integration-targets.md),
+[internal @v1 rule violation](/risks/internal-v1-violation.md),
+[release.yml force-push + sed rewrite fragility](/risks/release-yml-fragility.md),
+[failure summary lacks actionable detail](/risks/unhelpful-failure-summary.md),
+[dry-run/sandbox split-brain not surfaced honestly](/risks/dry-run-split-brain.md),
+[dead release-lock stub jobs](/risks/dead-release-lock-stubs.md).
+
+# Prioritized roadmap
+
+- **Phase 0 (days, near-zero risk):** delete dead stub jobs; fix the `@v1` violation + CI
+  grep-guard; add `concurrency:` group + per-job `timeout-minutes`; `pip install` smoke matrix +
+  `actionlint`.
+- **Phase 1 (weeks):** inputs/outputs contract test; orchestrator dry-run mode in CI; fix
+  freeze/unfreeze recovery model; failure summary with per-job checklist.
+- **Phase 2 (weeks–months):** idempotency on every mutating action; recovery runbook in
+  [AUTOMATED_RELEASE.md](/../docs/AUTOMATED_RELEASE.md); unified `dry-run` input; retries with
+  backoff on Jira/GitHub 5xx/429.
+- **Phase 3 (months):** integration harness against a dummy repo (GHA-247/249); extract
+  remaining inline shell to tested `.sh`; structured JSON input for integration targets;
+  harden [release.yml](/workflows/release.md).
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/decisions/env-var-injection-guard.md
+++ b/.okf/decisions/env-var-injection-guard.md
@@ -1,0 +1,39 @@
+---
+type: Decision
+title: "No user-controlled input interpolated directly into run: blocks"
+description: All action.yml inputs must be passed through environment variables rather than interpolated into shell, to prevent script injection.
+tags: [decision, security, script-injection]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Decision
+
+`action.yml` files must never interpolate `${{ inputs.x }}` directly inside a `run:` block.
+Inputs are passed through environment variables instead:
+
+```yaml
+# Bad — script injection risk
+run: echo "${{ inputs.branch }}"
+
+# Good
+env:
+  INPUT_BRANCH: ${{ inputs.branch }}
+run: echo "$INPUT_BRANCH"
+```
+
+# Why
+
+A crafted input value (e.g. a branch name containing `` `$(...)` ``) interpolated directly into
+a `run:` string is executed as shell — classic GitHub Actions script injection. Passing through
+`env:` neutralizes it because the value is never re-parsed as shell syntax.
+
+# How to apply
+
+Applies to every new or edited `action.yml`. The related `inputs.x || env.X` +
+`if [[ -z ]]` guard pattern (input precedence: explicit input > environment variable > default)
+must also stay per-action — see [vault blocks stay per-action](/decisions/vault-blocks-per-action.md).
+Removing either pattern during a refactor reintroduces injection risk or breaks precedence.
+
+# Citations
+
+[1] [CLAUDE.md § Security](/../CLAUDE.md)

--- a/.okf/decisions/golden-architecture.md
+++ b/.okf/decisions/golden-architecture.md
@@ -1,0 +1,49 @@
+---
+type: Decision
+title: Golden Architecture — actions as a public API, @master vs @v1
+description: Every action's inputs/outputs are a public API surface; internal refs use @master on master and get frozen to a SHA only on v1.
+tags: [decision, architecture, versioning, public-api]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Decision
+
+Every action is a self-contained composite invoked as
+`SonarSource/release-github-actions/<action>@v1`. Consumers pin `@v1`. Internal refactors within
+an action are transparent to consumers; **changing an action's `inputs:`/`outputs:` is a
+breaking change** and must be treated as a public API change.
+
+Source on `master` references sibling actions as `@master` (e.g.
+`SonarSource/release-github-actions/get-release-version@master`), so any test run from `master`
+exercises the latest code across all sub-actions. The [release workflow](/workflows/release.md)
+fast-forwards the `v1` branch to a release tag and then rewrites every `@master` ref to the
+exact release commit SHA — so `v1` is a self-consistent frozen snapshot with no floating refs.
+
+**New internal `uses:` must never be written as `@v1`** — not in `action.yml` files, not in
+`automated-release.yml`, not in test workflows (including string-match assertions like
+`grep -q "...@master"`). Always `@master`; the release workflow handles pinning.
+
+# Why
+
+- Lets `master` stay a coherent, always-current integration branch that CI actually exercises.
+- Lets `v1` (and future major versions) be an immutable, auditable snapshot that a squad's
+  release didn't silently drift out from under.
+- A rename/removal on `master` without a version bump would break every `@v1` consumer
+  mid-release, often after the branch is already frozen — see
+  [risk: input sprawl with undocumented invalid combinations](/risks/input-sprawl.md) and
+  [risk: no inputs/outputs contract test](/risks/no-contract-test.md) for how this is currently
+  under-enforced.
+
+# Violations found
+
+`automated-release.yml:907` references `update-plugins-deployer@v1` while every other internal
+ref uses `@master` — a confirmed rule violation caught by the
+[architecture review](/decisions/architecture-review-2026-07.md). The release-time `sed` only
+rewrites `@master`, so this ref was silently left floating, pinned to a different snapshot than
+its siblings. Recommended fix: correct the ref to `@master` and add a CI grep-guard so the rule
+is enforced, not just prose.
+
+# Citations
+
+[1] [CLAUDE.md § Golden Architecture](/../CLAUDE.md)
+[2] [docs/ARCHITECTURE_REVIEW.md § 4.3](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/decisions/index.md
+++ b/.okf/decisions/index.md
@@ -1,0 +1,7 @@
+# Decisions
+
+* [golden-architecture](golden-architecture.md) - actions as a public API; `@master` on master, frozen SHA on `v1`.
+* [vault-blocks-per-action](vault-blocks-per-action.md) - why Vault credential retrieval stays inline per action.
+* [env-var-injection-guard](env-var-injection-guard.md) - no user-controlled input interpolated directly into `run:` blocks.
+* [pin-external-actions](pin-external-actions.md) - external actions pinned to a full commit SHA, never a tag.
+* [architecture-review-2026-07](architecture-review-2026-07.md) - the 2026-07-14 review of the automated-release orchestrator; links to all findings under [risks/](../risks/).

--- a/.okf/decisions/pin-external-actions.md
+++ b/.okf/decisions/pin-external-actions.md
@@ -1,0 +1,36 @@
+---
+type: Decision
+title: External actions pinned to full commit SHA
+description: Every non-SonarSource GitHub Action reference must be pinned to a full commit SHA (with a version comment), never a mutable tag.
+tags: [decision, security, supply-chain]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Decision
+
+```yaml
+# Bad
+- uses: actions/checkout@v4
+
+# Good
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+```
+
+# Why
+
+Prevents tag-mutation supply-chain attacks, where a compromised or malicious maintainer moves a
+tag to point at different code without publishing a new version number. The March 2025
+`tj-actions/changed-files` tag-hijack (cited in the
+[architecture review](/decisions/architecture-review-2026-07.md) §6) is the cautionary tale
+motivating enforcement, not just documentation, of this rule.
+
+# How to apply
+
+Applies to every action reference outside the `SonarSource` GitHub organization. The rule
+exists and is followed today, but nothing in CI enforces it — the review recommends adopting
+`zizmor` or OpenSSF Scorecard so drift fails the build instead of relying on review vigilance.
+
+# Citations
+
+[1] [CLAUDE.md § Pinning External Actions](/../CLAUDE.md)
+[2] [docs/ARCHITECTURE_REVIEW.md § 6](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/decisions/vault-blocks-per-action.md
+++ b/.okf/decisions/vault-blocks-per-action.md
@@ -1,0 +1,35 @@
+---
+type: Decision
+title: Vault credential blocks stay inline per action
+description: Vault secret retrieval is duplicated in every action.yml rather than factored into a shared composite, to avoid leaking secrets via $GITHUB_ENV.
+tags: [decision, security, secrets, vault]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Decision
+
+Every action that needs Vault-sourced credentials (Jira tokens, Slack tokens, GitHub PAT for
+cross-repo PRs) repeats the `SonarSource/vault-action-wrapper@v3` block inline, rather than
+factoring it into a shared/nested composite action.
+
+# Why
+
+A nested composite action can only export secrets to the calling job via `$GITHUB_ENV` — which
+exposes the secret to **every later step in that job**, not just the step that needed it. This
+is a strictly wider blast radius than keeping the vault call inline where the secret is consumed.
+This is confirmed independently by the external best-practice research in the
+[architecture review](/decisions/architecture-review-2026-07.md) §6 as one of the things this
+repo already gets right.
+
+# How to apply
+
+This looks like duplication (per [CLAUDE.md](/../CLAUDE.md) it's called out explicitly as
+something that *looks like* duplication but must stay per-action) — do not "clean it up" into a
+shared composite during a refactor. The same non-negotiable applies to the
+`inputs.x || env.X` + `if [[ -z ]]` input-precedence guard pattern, mandated by
+[no user-controlled input in run: blocks](/decisions/env-var-injection-guard.md).
+
+# Citations
+
+[1] [CLAUDE.md § Things that LOOK like duplication but MUST stay per-action](/../CLAUDE.md)
+[2] [docs/ARCHITECTURE_REVIEW.md § 6](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -1,0 +1,22 @@
+---
+okf_version: "0.1"
+---
+
+# release-github-actions — Knowledge Bundle
+
+Reusable GitHub Actions and workflows automating the SonarSource analyzer release process:
+Jira integration, GitHub releases, cross-repository updates, and Slack notifications.
+
+# Directories
+
+* [actions/](actions/) - the 22 composite GitHub Actions in this repo, one concept per action.
+* [workflows/](workflows/) - the reusable `workflow_call` orchestrators (automated-release, ide-automated-release, abd-automated-release, release-lock) and the repo's own release workflow.
+* [shared/](shared/) - Python helpers shared across Jira-integration actions.
+* [decisions/](decisions/) - architectural rules and reviews governing this repo (Golden Architecture, security conventions, the 2026-07 architecture review).
+* [risks/](risks/) - individual reliability/testability/maintainability findings from the architecture review, one concept per finding.
+
+# Start here
+
+* [automated-release](workflows/automated-release.md) - the main orchestrator; read this first to understand how the actions fit together.
+* [Golden Architecture](decisions/golden-architecture.md) - the versioning/API-surface rule that governs every action.
+* [Architecture Review (2026-07-14)](decisions/architecture-review-2026-07.md) - TL;DR of known reliability and testability gaps.

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,0 +1,4 @@
+# Update Log
+
+## 2026-07-15
+* **Creation**: Established the OKF bundle for this repository — [actions/](/actions/) (22 composite actions), [workflows/](/workflows/) (5 reusable workflows), [shared/](/shared/) (the Jira helper module), [decisions/](/decisions/) (Golden Architecture and security conventions, plus the 2026-07-14 architecture review), and [risks/](/risks/) (14 individual findings distilled from [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)).

--- a/.okf/risks/dead-release-lock-stubs.md
+++ b/.okf/risks/dead-release-lock-stubs.md
@@ -1,0 +1,26 @@
+---
+type: Risk
+title: Dead set-release-lock/clear-release-lock stub jobs misrepresent guarantees
+description: No-op jobs are surrounded by comments describing locking behavior that does not actually happen — a scar from the GHA-355 revert.
+tags: [risk, dead-code, documentation, p2]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+`set-release-lock` and `clear-release-lock` (`automated-release.yml:292`–`299`, `723`–`731`) are
+no-op `echo "Skipped…"` jobs, but their surrounding comments describe elaborate PR-locking
+behavior that **does not happen**. A future reader believes other PRs are locked during a
+release when they aren't. This is a scar from GHA-355, where the actual sweep was reverted after
+breaking releases across multiple repos — the real mechanism today is
+[release-lock](/workflows/release-lock.md), a separate opt-in required-status-check workflow.
+
+# Recommendation
+
+Either wire the token and make the stub jobs actually work, or delete the jobs *and* the
+aspirational comments. Don't ship scaffolding that lies about the guarantees it provides.
+Near-zero risk, do first.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 7](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/dry-run-split-brain.md
+++ b/.okf/risks/dry-run-split-brain.md
@@ -1,0 +1,32 @@
+---
+type: Risk
+title: Draft/sandbox split-brain is not surfaced honestly
+description: use-jira-sandbox and is-draft-release both default true, but GitHub has no sandbox — a "dry run" still publishes a real release/tag.
+tags: [risk, observability, dry-run, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+`use-jira-sandbox` defaults **true**; `is-draft-release` defaults **true**. GitHub has no
+sandbox concept — a "dry-run" publishes a **real** GitHub release/tag while filing Jira in
+sandbox, and the banner still stamps "DRY RUN." GitHub=prod, Jira=sandbox, banner=dry-run: a
+split-brain. Conversely, a *successful production* run leaves the GitHub release and analyzer
+PRs as **drafts** with nothing screaming "still a draft — go publish it."
+
+# Failure scenario
+
+A DRI runs what they believe is a safe dry-run test and is surprised to find a real (draft)
+GitHub release and real analyzer-update PRs exist afterward — because "dry-run" only ever meant
+"Jira sandbox," not "no side effects anywhere."
+
+# Recommendation
+
+- Collapse to one `dry-run` input that fans out to Jira sandbox + GitHub draft + PR draft.
+- Make the summary banner reflect the *actual* combination in effect, not just the Jira flag; if
+  GitHub can't be sandboxed, say so loudly.
+- When `is-draft-release=true && !dry-run`, add "⚠️ Draft — not yet public, publish manually."
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 5.2](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/fragile-version-parsing.md
+++ b/.okf/risks/fragile-version-parsing.md
@@ -1,0 +1,29 @@
+---
+type: Risk
+title: Fragile, untested release-version parsing feeds every downstream job
+description: get-release-version parses the version out of a human-readable repox status description with no unit test guarding the format.
+tags: [risk, reliability, testability, get-release-version, p2]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+[get-release-version](/actions/get-release-version.md) parses the release version out of a
+human-readable repox commit-status **description** via
+`... | .description | split("'")[1]` — inline `jq` in `action.yml`, no unit test. Every
+downstream job in [automated-release](/workflows/automated-release.md) keys off this output.
+
+# Failure scenario
+
+The repox status text format changes upstream (a wording tweak, a punctuation change). Every
+release breaks with a cryptic "Could not extract release version," and nothing caught it before
+a real release run.
+
+# Recommendation
+
+Extract the parse into a tested `get_release_version.sh` (or `.py`) with `test_*` cases for the
+known status-text formats and a clear failure message; assert the shape (`X.Y.Z.build`).
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 2.6](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/hardcoded-integration-targets.md
+++ b/.okf/risks/hardcoded-integration-targets.md
@@ -1,0 +1,26 @@
+---
+type: Risk
+title: SonarSource-specific hardcoding makes "reusable" aspirational
+description: Jira project keys and custom field IDs for integration targets are string literals baked into the orchestrator, not configuration.
+tags: [risk, maintainability, hardcoding, p2]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+Project keys `SLVS`, `SLVSCODE`, `SLE`, `SLI`, `CLI`, `SC`, `SONAR` are hardcoded as string
+literals in the fan-out steps of [automated-release](/workflows/automated-release.md)
+(`:763`–`:841`). Adding a new integration target means editing the 1,100-line orchestrator, not
+passing config. Custom field IDs (see [shared/jira_common.py](/shared/jira-common.md)) and the
+KTLO epic notion are SonarSource-tenant constants baked into ostensibly "reusable" code.
+
+# Recommendation
+
+Push the integration-target list into a structured JSON input (`[{project, description, epic}]`)
+parsed inside the step via `fromJSON`. Targets become data, not code — the orchestrator stops
+growing a hardcoded step per new target. Won't fully de-Sonar the repo, but caps the growth; see
+also [input sprawl](/risks/input-sprawl.md), which this partially addresses.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 4.2](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/index.md
+++ b/.okf/risks/index.md
@@ -1,0 +1,34 @@
+# Risks
+
+Findings from the [2026-07-14 architecture review](../decisions/architecture-review-2026-07.md)
+of [automated-release](../workflows/automated-release.md), one concept per finding.
+
+# Reliability (P0/P1)
+
+* [no-idempotency](no-idempotency.md) - no mutating step in the release pipeline is idempotent.
+* [unfreeze-on-failure](unfreeze-on-failure.md) - `always()` unfreeze thaws the branch even on a failed release.
+* [no-concurrency-guard](no-concurrency-guard.md) - no concurrency guard on the orchestrator.
+* [fragile-version-parsing](fragile-version-parsing.md) - untested version parsing feeds every downstream job.
+
+# Testability (P0/P1)
+
+* [orchestrator-untested](orchestrator-untested.md) - the orchestrator's control flow has no test.
+* [untested-inline-shell](untested-inline-shell.md) - bash/inline-shell actions with real logic have no unit test.
+* [no-contract-test](no-contract-test.md) - no inputs/outputs contract test; silent `@v1` breaking changes ship.
+
+# Maintainability (P1/P2)
+
+* [input-sprawl](input-sprawl.md) - ~50-input sprawl with silent invalid combinations.
+* [hardcoded-integration-targets](hardcoded-integration-targets.md) - SonarSource-specific hardcoding makes "reusable" aspirational.
+* [internal-v1-violation](internal-v1-violation.md) - a confirmed `@v1` rule violation in `automated-release.yml`.
+* [release-yml-fragility](release-yml-fragility.md) - `release.yml`'s force-push + sed rewrite has no post-write assertions.
+
+# Observability (P1/P2)
+
+* [unhelpful-failure-summary](unhelpful-failure-summary.md) - failure summary doesn't say what failed or what to do.
+* [dry-run-split-brain](dry-run-split-brain.md) - draft/sandbox split-brain is not surfaced honestly.
+
+# Cleanups / ecosystem context
+
+* [dead-release-lock-stubs](dead-release-lock-stubs.md) - dead stub jobs misrepresent guarantees.
+* [stale-releasability-status](stale-releasability-status.md) - the standalone `check-releasability-status` action can read a stale status (not a defect in the orchestrator itself).

--- a/.okf/risks/input-sprawl.md
+++ b/.okf/risks/input-sprawl.md
@@ -1,0 +1,34 @@
+---
+type: Risk
+title: ~50-input sprawl with silent invalid combinations
+description: Mutually coupled inputs on automated-release have undocumented valid combinations, some of which disagree with the schema.
+tags: [risk, maintainability, inputs, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+[automated-release](/workflows/automated-release.md) has ~50 inputs, many coupled through `if:`
+expressions, with valid combinations undocumented and unenforced:
+
+- `sqaa-integration: true` with `sqc-integration: false` → the job is silently skipped (`:946`).
+- `sqc-plugins-deployer-integration` is a **deprecated no-op** still in the schema with
+  `default: true` — appears in every dispatch form and setup doc.
+- `rule-props-changed` is a required *string* `"true"`/`"false"` compared with `== 'true'`
+  (`:537`): pass a real boolean or `"True"` and it silently maps to "No."
+- `new-version` is documented **required** in [AUTOMATED_RELEASE.md](/../docs/AUTOMATED_RELEASE.md)
+  but is `required: false` in the YAML (`:91`) — omitting it changes what Jira creates next, and
+  **docs and schema disagree**.
+
+# Recommendation
+
+1. Prune deprecated inputs (`sqc-plugins-deployer-integration`); make booleans real booleans.
+2. Reconcile docs vs. schema on `new-version`.
+3. Collapse the integration-target scalars into one structured input — see
+   [hardcoded integration targets](/risks/hardcoded-integration-targets.md).
+4. Validate mutually-exclusive/invalid combinations early with a clear error instead of silently
+   skipping jobs.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 4.1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/internal-v1-violation.md
+++ b/.okf/risks/internal-v1-violation.md
@@ -1,0 +1,29 @@
+---
+type: Risk
+title: automated-release.yml:907 references @v1 instead of @master
+description: A confirmed violation of the Golden Architecture rule, silently left unpinned by the release-time sed rewrite.
+tags: [risk, maintainability, golden-architecture, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+`automated-release.yml:907` references `update-plugins-deployer@v1`, while every other internal
+ref in the file uses `@master` — a confirmed violation of
+[the Golden Architecture rule](/decisions/golden-architecture.md) that internal `uses:` must
+never be written as `@v1`. Because [release.yml](/workflows/release.md)'s `sed` only rewrites
+`@master` refs, this one is silently left floating: on the `v1` snapshot,
+[update-plugins-deployer](/actions/update-plugins-deployer.md) resolves to a different (later,
+moving) snapshot than every one of its sibling actions.
+
+# Recommendation
+
+1. Fix `:907` to `@master`.
+2. Add a CI grep-guard that fails on any `SonarSource/release-github-actions/...@v1` string
+   appearing anywhere in the repo — making the rule enforced, not prose-only.
+3. Consider a `v1-rc` staging branch so `master` isn't simultaneously "dev" and "what tests run
+   against."
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 4.3](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/no-concurrency-guard.md
+++ b/.okf/risks/no-concurrency-guard.md
@@ -1,0 +1,35 @@
+---
+type: Risk
+title: No concurrency guard on the release orchestrator
+description: Two overlapping releases on the same branch can race Jira version release, GitHub release publication, and freeze/unfreeze.
+tags: [risk, reliability, concurrency, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+`grep concurrency automated-release.yml` finds nothing. Two DRIs, or one double-click on
+`workflow_dispatch`, can start two overlapping runs of
+[automated-release](/workflows/automated-release.md) on the same branch.
+
+# Failure scenario
+
+Two runs both pass [check-releasability](/actions/check-releasability-status.md), both reach
+[release-jira-version](/actions/release-jira-version.md) — one releases the Jira version, the
+other's "already released" call (which doesn't exist — see
+[no idempotency](/risks/no-idempotency.md)) errors ambiguously, or worse, both publish competing
+GitHub releases.
+
+# Recommendation
+
+A one-line native fix:
+
+```yaml
+concurrency:
+  group: release-${{ inputs.branch }}
+  cancel-in-progress: false   # queue, don't cancel a release mid-flight
+```
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 2.3](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/no-contract-test.md
+++ b/.okf/risks/no-contract-test.md
@@ -1,0 +1,34 @@
+---
+type: Risk
+title: No inputs/outputs contract test — silent @v1 breaking changes ship
+description: Nothing enforces that an action's inputs/outputs are treated as the public API CLAUDE.md declares them to be.
+tags: [risk, testability, breaking-change, golden-architecture, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+[CLAUDE.md](/../CLAUDE.md) declares an action's `inputs:`/`outputs:` a public API — see
+[Golden Architecture](/decisions/golden-architecture.md). **Nothing enforces this.** Rename an
+input, change a default, drop an output — CI stays green,
+[release.yml](/workflows/release.md) cuts a `v1` snapshot anyway, and the next squad release
+fails mid-release, after the branch is frozen and the GitHub release is published.
+
+# Failure scenario
+
+A refactor renames an input on `master` for internal clarity, forgetting a consumer still
+passes the old name via `@v1`. The rename ships in the next release cut. Weeks later a squad
+triggers their release; the input silently doesn't apply (or the workflow errors) partway
+through the DAG, with the branch already frozen.
+
+# Recommendation
+
+A golden-file contract test: dump each `action.yml`'s input/output names + `required` +
+`default` to a checked-in snapshot; CI diffs and fails on change, forcing a conscious "yes, this
+is breaking" acknowledgment and a major-version bump conversation. Small script, catches the
+highest-consequence mistake class in the repo.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 3.3](/../docs/ARCHITECTURE_REVIEW.md)
+[2] [CLAUDE.md § Golden Architecture](/../CLAUDE.md)

--- a/.okf/risks/no-idempotency.md
+++ b/.okf/risks/no-idempotency.md
@@ -1,0 +1,57 @@
+---
+type: Risk
+title: No mutating step in the release pipeline is idempotent
+description: A failure partway through the release DAG leaves published GitHub releases, unreleased Jira versions, and duplicate tickets with no safe re-run.
+tags: [risk, reliability, idempotency, p0]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+The [automated-release](/workflows/automated-release.md) job DAG performs irreversible actions
+in an order hostile to partial failure:
+
+```
+freeze → check → prepare → create-release-ticket → publish-github-release
+   → UNFREEZE → release-in-jira → bump-version → integration-tickets → analyzer PRs
+```
+
+If [publish-github-release](/actions/publish-github-release.md) succeeds and
+[release-jira-version](/actions/release-jira-version.md) then fails, the result is a published
+GitHub release/tag, a Jira version not released with no next version created, and a REL ticket
+stuck "In Progress."
+
+Idempotency is **inconsistent**, not uniformly absent, which is arguably worse — you can't
+reason about what a re-run will do:
+
+- [publish-github-release](/actions/publish-github-release.md) is *partially* idempotent — it
+  reuses an existing draft release by title — but only for the draft case; a re-run after a
+  *published* release is unguarded.
+- [create-jira-release-ticket](/actions/create-jira-release-ticket.md) is not idempotent —
+  nothing checks whether a REL ticket for this version already exists.
+- [release-jira-version](/actions/release-jira-version.md) /
+  [create-jira-version](/actions/create-jira-version.md) have no "already released?" check.
+
+The workflow admits it can't resume: the rule-metadata gate literally says "start a new run
+instead of re-running failed jobs."
+
+# Failure scenario
+
+Jira has a transient timeout right after the GitHub release is published. The DRI sees a failed
+job, has no runbook, and either re-runs (risking a duplicate REL ticket / double release attempt)
+or manually patches Jira state while the branch sits in an ambiguous state.
+
+# Recommendation
+
+1. Make each mutating action check-then-act idempotent (query "does X already exist / is it
+   already in state Y?" before creating/mutating).
+2. Until then, ship a per-failure-point recovery runbook in
+   [AUTOMATED_RELEASE.md](/../docs/AUTOMATED_RELEASE.md) keyed by "last successful job."
+3. Stage reversible work first, commit irreversible work last (the saga/two-phase pattern).
+
+**Re-run gotcha:** GitHub "re-run failed jobs" replays the cached workflow *definition* — a YAML
+bugfix requires a fresh run, not a re-run.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 2.1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/orchestrator-untested.md
+++ b/.okf/risks/orchestrator-untested.md
@@ -1,0 +1,38 @@
+---
+type: Risk
+title: The orchestrator's control flow has no test
+description: "needs:/if: wiring and output plumbing across ~15 jobs and ~50 inputs is exercised only in production, not in CI."
+tags: [risk, testability, orchestrator, p0]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+[automated-release](/workflows/automated-release.md) is ~1,100 lines, ~50 inputs, 15 jobs wired
+by hand-written `needs:` + multi-clause `if:` guards. `test-all.yml` fans out to **per-action**
+tests only — nothing instantiates the orchestrator itself, so the logic deciding whether a
+release proceeds or corrupts is unexercised:
+
+- The `!cancelled() && (result == 'success' || == 'skipped')` pattern is a footgun: add a new
+  gate job upstream and forget its `skipped` clause, and the gate is silently bypassed. GHA-226
+  and GHA-227 are this exact bug class, in production — a skipped
+  [update-rule-metadata](/actions/update-rule-metadata.md) silently skipped unfreeze too.
+- `summarize-release` computes `ALL_SUCCESS` from a hand-maintained `RESULT_*` list
+  (`:993`, with a comment begging editors to keep two lists in sync). Miss one and a failed
+  release reports "🎉 Successful."
+- A typo in `needs.<job>.outputs.<x>` resolves to an empty string, not an error — so
+  `release-version: ""` flows downstream and detonates three jobs later, far from the cause.
+
+# Recommendation
+
+1. Add a dry-run mode to the orchestrator (`if: !inputs.dry-run` on every side-effecting step).
+   Run it in CI to assert the DAG resolves, `if:` gates behave, and output plumbing connects —
+   no Jira/GitHub mutation. Highest-value test; directly closes the GHA-226/227 class.
+2. Adopt `actionlint` (syntax + `needs` reference validation) plus a lint that flags any
+   `needs.X` where `X` isn't declared in the job's `needs:` list.
+3. Build the integration harness that already has a ticket — GHA-247 (epic) / GHA-249 (dummy
+   analyzer repo + mocked repox status), currently "To Do."
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 3.1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/release-yml-fragility.md
+++ b/.okf/risks/release-yml-fragility.md
@@ -1,0 +1,33 @@
+---
+type: Risk
+title: release.yml's force-push + sed rewrite has no post-write assertions
+description: The pinning of @master refs to a release SHA can silently fail partially, or the force-push can silently no-op, with no alarm either way.
+tags: [risk, maintainability, release-yml, p2]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+[release.yml](/workflows/release.md) does `git reset --hard $TAG` → `sed` rewrite
+`@master`→SHA → `git push --force-with-lease`, with several fragilities:
+
+- `sed` only rewrites `@master`; an internal `@v1` ref (see
+  [internal @v1 violation](/risks/internal-v1-violation.md)) or an oddly-spaced ref is silently
+  not pinned — and there is **no post-sed assertion** that zero `@master` refs remain.
+- `--force-with-lease` on a shared consumer-facing branch: if the lease fails, `v1` **silently**
+  doesn't update and consumers keep resolving the old snapshot, with no alarm.
+- `git commit ... || true` (`:53`) swallows *all* commit failures as "nothing changed," not just
+  the intended "no diff" case.
+- No verification that the rewritten `v1` is internally consistent (e.g. no remaining
+  cross-references to `master`).
+
+# Recommendation
+
+After the `sed`, assert `! grep -rn '@master'` on the rewritten files (and no internal `@v1`)
+and fail loudly if either check fails. Replace `commit || true` with an explicit "is the diff
+empty?" check. Keep immutable `v1.2.3` tags alongside the moving `v1` branch so a bad
+force-push is recoverable.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 4.4](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/stale-releasability-status.md
+++ b/.okf/risks/stale-releasability-status.md
@@ -1,0 +1,26 @@
+---
+type: Risk
+title: check-releasability-status (standalone action) can read a stale commit status
+description: The standalone action reads whatever status is currently posted; the orchestrator itself avoids this by using the exact commit SHA via an external action.
+tags: [risk, releasability, ecosystem-context, p2]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+Historically, `check-releasability` reads reported green when a Jira-optional check was actually
+stale/failed, and separately later *failed* releases on stale optional checks (XP squad, Feb
+2026). This applies to the standalone
+[check-releasability-status](/actions/check-releasability-status.md) action, which reads
+whatever `Releasability` commit status is currently posted for a branch — there's an inherent
+staleness window between "status posted" and "status read."
+
+**Important scoping note:** [automated-release](/workflows/automated-release.md) itself does
+**not** depend on this standalone action for its own releasability gate — the orchestrator calls
+`SonarSource/gh-action_releasability@v3` directly with the exact `commit-sha` (`:351`), which
+sidesteps the staleness window. This risk is ecosystem context (repos that use the standalone
+action directly), not a defect in the release orchestrator's own path.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/unfreeze-on-failure.md
+++ b/.okf/risks/unfreeze-on-failure.md
@@ -1,0 +1,38 @@
+---
+type: Risk
+title: unfreeze-branch uses always() — thaws the branch even on a failed release
+description: The branch unlocks unconditionally after the publish step, opening it to other merges exactly when the release is in its most fragile, half-done state.
+tags: [risk, reliability, freeze-branch, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+`automated-release.yml:603` — `if: ${{ always() && inputs.freeze-branch }}`. If
+[publish-github-release](/actions/publish-github-release.md) fails, the branch still unfreezes
+via [lock-branch](/actions/lock-branch.md). Combined with
+[no idempotency](/risks/no-idempotency.md), this produces a half-published release **and** an
+open branch that other developers' PRs immediately merge into — the one guardrail (freeze)
+releases exactly when the branch most needs to stay held for cleanup.
+
+This is also the mechanism behind GHA-227: the transitive-skip bug meant unfreeze was *skipped*
+(master left frozen) — the opposite failure, same root cause: freeze lifecycle is driven by
+fragile job-graph semantics (`needs:`/`if:`), not an explicit state machine.
+
+# Failure scenario
+
+`publish-github-release` fails after freeze. `always()` fires the unfreeze anyway. A developer's
+unrelated PR merges into the now-open, half-released branch before anyone notices the release is
+broken.
+
+# Recommendation
+
+Split the unfreeze decision: unfreeze on success or early abort (nothing published yet); keep
+frozen on failure *after* publish, with a loud Slack line — "⚠️ branch left frozen — release
+reached an inconsistent state, manual cleanup required." Make freeze/unfreeze itself idempotent
+and retried (a bare API blip on unfreeze currently just reds the job with no retry — the MI1162
+"stuck frozen" shape).
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 2.2](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/unhelpful-failure-summary.md
+++ b/.okf/risks/unhelpful-failure-summary.md
@@ -1,0 +1,27 @@
+---
+type: Risk
+title: Failure summary doesn't say what failed or what to do
+description: On failure the Slack summary collapses to generic "re-run as needed" advice that is actively dangerous given the idempotency gap.
+tags: [risk, observability, failure-summary, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+The happy-path summary (`automated-release.yml:1036`–`1083`) puts all relevant URLs in one
+Slack message — genuinely good. On failure it collapses to *"One or more jobs failed… re-run as
+needed"*, which — given [no idempotency](/risks/no-idempotency.md) — is **actively dangerous**
+advice. It doesn't name the failing job in Slack (you must open the Actions run), even though
+per-job `RESULT_*` values are already collected and then thrown away into a single boolean.
+`verbose` defaults to `false`, so out of the box you get the *least* diagnostic detail.
+
+# Recommendation
+
+- Always print the per-job ✅/❌ checklist in the failure summary (the data already exists).
+- Name the first failing job plus a one-line "what this usually means / what to do," pointing at
+  the recovery runbook from [no idempotency](/risks/no-idempotency.md).
+- Replace "re-run as needed" with idempotency-aware guidance.
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 5.1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/risks/untested-inline-shell.md
+++ b/.okf/risks/untested-inline-shell.md
@@ -1,0 +1,35 @@
+---
+type: Risk
+title: Bash/inline-shell actions with real logic have no unit test
+description: The Python-vs-Bash test split is arbitrary — logic extracted to a .sh got tested, logic left inline in action.yml did not.
+tags: [risk, testability, bash, p1]
+timestamp: 2026-07-14T00:00:00Z
+---
+
+# Observation
+
+Where logic was extracted to a `.sh` file, it has a test:
+[bump-version](/actions/bump-version.md),
+[update-plugins-deployer](/actions/update-plugins-deployer.md),
+[update-rule-metadata](/actions/update-rule-metadata.md). Where it stayed inline in `action.yml`,
+it has none:
+
+- [get-release-version](/actions/get-release-version.md) — feeds every downstream job, no test
+  (see [fragile version parsing](/risks/fragile-version-parsing.md)).
+- [get-jira-version](/actions/get-jira-version.md),
+  [publish-github-release](/actions/publish-github-release.md),
+  [check-releasability-status](/actions/check-releasability-status.md),
+  [update-analyzer](/actions/update-analyzer.md) (121 lines) — inline shell, no unit test.
+  `test-update-analyzer.yml` "tests" *expect the action to fail* on missing vault access — a
+  linter with extra steps, not a behavior test.
+
+# Recommendation
+
+Enforce the rule the repo already half-follows: inline shell longer than ~10 lines must be
+extracted to a `.sh` with a `test_*.sh` (bats or plain assert). Prioritize
+[get-release-version](/actions/get-release-version.md) and
+[update-analyzer](/actions/update-analyzer.md).
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md § 3.2](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/shared/index.md
+++ b/.okf/shared/index.md
@@ -1,0 +1,3 @@
+# Shared modules
+
+* [jira-common](jira-common.md) - Jira URL resolution, custom field IDs, and auth shared by every Jira-integration action.

--- a/.okf/shared/jira-common.md
+++ b/.okf/shared/jira-common.md
@@ -1,0 +1,47 @@
+---
+type: Shared Module
+title: shared/jira_common.py
+description: Single source of truth for Jira URL resolution, custom field IDs, and Jira client auth used by every Jira-integration action.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/shared/jira_common.py
+tags: [shared, jira, python]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Imported by each Python action via a `sys.path` insert (works because `@v1` checks out the
+whole repo, so `../shared` is on disk at runtime). Deliberately **not** packaged with
+`pyproject.toml` / `pip install -e .` — that would force an install step into every consumer
+workflow (a prior attempt was reverted, commit `ad8a663`).
+
+Rule of thumb from [CLAUDE.md](/../CLAUDE.md): if a helper exists in ≥2 actions and a third copy
+is needed, it belongs here with a `test_*.py`.
+
+# Schema
+
+| Symbol | Purpose |
+|---|---|
+| `JIRA_URL_PROD` / `JIRA_URL_SANDBOX` | The two Jira base URLs |
+| `get_jira_url(use_sandbox)` | Resolves the URL; accepts bool, `'true'`/`'false'` string, or `None` |
+| `get_jira_instance(use_sandbox)` | Authenticates via `JIRA_USER`/`JIRA_TOKEN` env vars, `sys.exit(1)` on failure |
+| `eprint(*args, **kwargs)` | Prints to stderr — keeps diagnostics separate from stdout, which carries the result piped to `$GITHUB_OUTPUT` |
+| `CUSTOM_FIELDS` | Dict of Jira custom field IDs (also documented in CLAUDE.md) |
+
+`CUSTOM_FIELDS` values: `SHORT_DESCRIPTION` → `customfield_10146`,
+`LINK_TO_RELEASE_NOTES` → `customfield_10145`, `DOCUMENTATION_STATUS` → `customfield_10147`,
+`RULE_PROPS_CHANGED` → `customfield_11263`, `SONARLINT_CHANGELOG` → `customfield_11264`.
+
+Used by [create-jira-release-ticket](/actions/create-jira-release-ticket.md),
+[create-jira-version](/actions/create-jira-version.md),
+[create-integration-ticket](/actions/create-integration-ticket.md),
+[get-jira-release-notes](/actions/get-jira-release-notes.md),
+[release-jira-version](/actions/release-jira-version.md),
+[resolve-ktlo-epic](/actions/resolve-ktlo-epic.md), and
+[update-release-ticket-status](/actions/update-release-ticket-status.md). URL resolution lives
+**only** here — no `action.yml` constructs a Jira URL directly; a future domain change is one
+edit in this file.
+
+# Citations
+
+[1] [shared/jira_common.py](/../shared/jira_common.py)
+[2] [CLAUDE.md § Jira URL resolution](/../CLAUDE.md)

--- a/.okf/workflows/abd-automated-release.md
+++ b/.okf/workflows/abd-automated-release.md
@@ -1,0 +1,19 @@
+---
+type: Reusable Workflow
+title: ABD Automated Release
+description: A distinct reusable release-orchestration variant, out of scope for the 2026-07 architecture review.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/abd-automated-release.yml
+tags: [workflow, release, orchestrator]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+A ~330-line reusable release workflow variant, separate from
+[automated-release](/workflows/automated-release.md) (the analyzer path) and
+[ide-automated-release](/workflows/ide-automated-release.md) (the DevEx path). Explicitly out of
+scope for the [architecture review](/decisions/architecture-review-2026-07.md).
+
+# Citations
+
+[1] [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -1,0 +1,96 @@
+---
+type: Reusable Workflow
+title: Automated Release (analyzer path)
+description: Orchestrates the full end-to-end analyzer release across Jira, GitHub, and downstream integration repos.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/automated-release.yml
+tags: [workflow, release, orchestrator, jira, github-release]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+~1,100-line reusable `workflow_call` workflow, ~50 inputs, ~15 jobs wired by hand-written
+`needs:` + `if:` guards. Triggered manually via `workflow_dispatch` from an analyzer repo. This
+is the generic **analyzer** release path — distinct from
+[ide-automated-release](/workflows/ide-automated-release.md) (DevEx/IDE) and
+[abd-automated-release](/workflows/abd-automated-release.md), which are separate paths.
+
+# Job DAG
+
+```
+disable-auto-merge (if bump-version: true)
+        │
+        ▼
+  freeze-branch (optional, lock_branch via lock-branch action)
+        │
+        ▼
+  check-releasability (SonarSource/gh-action_releasability@v3, exact commit SHA)
+        │
+        ▼
+  prepare-release (get-release-version, get-jira-version, get-jira-release-notes)
+        │
+   ┌────┴─────────────────────┐
+   ▼                          ▼
+create-release-ticket   publish-github-release
+   │                          │
+   └───────────┬──────────────┘
+               ▼
+          UNFREEZE branch
+               │
+               ▼
+        release-in-jira (release-jira-version, create-jira-version for next)
+               │
+       ┌───────┴────────────────────┐
+       ▼                            ▼
+  bump-version                create-integration-tickets (SLVS/SLE/SLI/SQS/SQC/...)
+  (opens version-bump PR)            │
+                                     ▼
+                            update-analyzer PRs (sonar-enterprise, sonar-plugins-deployer)
+```
+
+Actions composed: [get-release-version](/actions/get-release-version.md),
+[get-jira-version](/actions/get-jira-version.md),
+[get-jira-release-notes](/actions/get-jira-release-notes.md),
+[create-jira-release-ticket](/actions/create-jira-release-ticket.md),
+[publish-github-release](/actions/publish-github-release.md),
+[release-jira-version](/actions/release-jira-version.md),
+[create-integration-ticket](/actions/create-integration-ticket.md),
+[update-analyzer](/actions/update-analyzer.md),
+[update-plugins-deployer](/actions/update-plugins-deployer.md),
+[update-analysis-as-a-service](/actions/update-analysis-as-a-service.md),
+[update-release-ticket-status](/actions/update-release-ticket-status.md),
+[bump-version](/actions/bump-version.md), and branch lock/unlock via
+[lock-branch](/actions/lock-branch.md) (external:
+`SonarSource/gh-action_releasability@v3`, `sonarsource/gh-action-lt-backlog/ToggleLockBranch`).
+
+# Schema
+
+Key inputs (selected — full list in the action README): `jira-project-key`, `project-name`,
+`plugin-name`, `pm-email`, `short-description`, `rule-props-changed`, `branch`, `new-version`,
+`use-jira-sandbox` (default `true`), `is-draft-release` (default `true`), `freeze-branch`
+(default `true`), `check-releasability` (default `true`), `sqs-integration` /
+`sqc-integration` (default `true`), `sqaa-integration` (runs only when `sqc-integration` is
+also true; silently skipped if not onboarded), `create-slvs-ticket` / `create-slvscode-ticket` /
+`create-sle-ticket` / `create-sli-ticket` / `create-cli-ticket` (default `false`), `verbose`
+(default `false`).
+
+Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
+
+# Notes
+
+- **Auto-merge sweep**: when `bump-version: true`, strips auto-merge from all open PRs at
+  release start, to reduce the race window where a PR could merge before the version-bump PR
+  opens. Best-effort — see the [release-lock gate](/workflows/release-lock.md) for the guard of
+  last resort.
+- **Freeze window ends early**: the branch unfreezes right after
+  [publish-github-release](/actions/publish-github-release.md), *before* the version-bump PR is
+  created — see [release-lock](/workflows/release-lock.md) for how that gap is closed.
+- This workflow has been the subject of an [architecture review](/decisions/architecture-review-2026-07.md)
+  identifying reliability, testability, and observability gaps — see the
+  [risks](/risks/index.md) directory.
+
+# Citations
+
+[1] [README.md](/../README.md)
+[2] [docs/AUTOMATED_RELEASE.md](/../docs/AUTOMATED_RELEASE.md)
+[3] [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/workflows/ide-automated-release.md
+++ b/.okf/workflows/ide-automated-release.md
@@ -1,0 +1,21 @@
+---
+type: Reusable Workflow
+title: IDE Automated Release (DevEx path)
+description: Reusable release orchestration for SonarLint / Development Experience projects, separate from the analyzer path.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/ide-automated-release.yml
+tags: [workflow, release, orchestrator, devex, sonarlint]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Reusable `workflow_call` workflow for Development Experience projects (SonarLint Core,
+SonarLint for IntelliJ, SonarLint for Eclipse, SonarLint for VS Code, etc.), set up via the
+`devex-release-setup` Claude Code skill. Explicitly out of scope for the
+[architecture review](/decisions/architecture-review-2026-07.md), which covers only the
+analyzer path ([automated-release](/workflows/automated-release.md)). Roughly a fifth the size
+of the analyzer orchestrator (~240 lines vs. ~1,100).
+
+# Citations
+
+[1] [README.md](/../README.md)

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -1,0 +1,7 @@
+# Workflows
+
+* [automated-release](automated-release.md) - the analyzer release orchestrator; the main entry point for this repo.
+* [ide-automated-release](ide-automated-release.md) - the DevEx/IDE (SonarLint) release orchestrator.
+* [abd-automated-release](abd-automated-release.md) - a distinct release-orchestration variant.
+* [release-lock](release-lock.md) - required-status-check gate that blocks other PRs while a version-bump PR is open.
+* [release](release.md) - this repo's own release workflow; fast-forwards `v1` and pins internal refs.

--- a/.okf/workflows/release-lock.md
+++ b/.okf/workflows/release-lock.md
@@ -1,0 +1,54 @@
+---
+type: Reusable Workflow
+title: Release Lock
+description: Sets a release-lock GitHub commit status that blocks other PRs from merging while a version-bump PR is open.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/release-lock.yml
+tags: [workflow, release, branch-protection, required-check]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Closes the gap left by [automated-release](/workflows/automated-release.md)'s early unfreeze:
+the branch reopens right after the GitHub release publishes, but *before* the version-bump PR
+(from [bump-version](/actions/bump-version.md)) is created. That gap lets other PRs merge into
+an unbumped branch. Freeze (`lock_branch`) can't cover the gap — it's all-or-nothing, including
+for the release DRI, and the bump PR push itself needs an unfrozen branch.
+
+The fix: a required-status-check signal, "a version-bump PR is open," implemented as a thin
+per-repo `release-lock.yml` caller that delegates to this reusable workflow.
+
+# Schema
+
+Input: `bump-branch-prefix` (default `bot/prepare-next-development-iteration-`) — identifies the
+version-bump PR by its head branch prefix, invariant across Maven/Gradle/custom paths.
+
+| Condition | Status on other PRs | Status on bump PR |
+|---|---|---|
+| No bump PR open | ✅ success — "No release in progress" | — |
+| Bump PR open | ❌ failure — "Release in progress — merge the version-bump PR first" | ✅ success |
+| Bump PR merged/abandoned | ✅ success (auto-reset) | — |
+
+When the bump PR closes, the workflow sweeps all open PRs (paginated, drafts included) and
+resets each to green automatically.
+
+# Adoption
+
+Two-phase, per repo, via the `automated-release-setup` skill:
+
+1. **Phase 1 (unenforced)** — add the thin `release-lock.yml` caller; observe over one or two
+   real releases.
+2. **Phase 2 (enforce)** — register `release-lock` as a required status check on the branch.
+
+The gate is opt-in and non-breaking: a repo without it releases exactly as before. Once
+[lock-branch](/actions/lock-branch.md)'s freeze/unfreeze preserves
+`required_status_checks.contexts` (it does, by design), the `release-lock` check survives every
+freeze/unfreeze cycle once registered.
+
+A future release will flip `automated-release`'s `freeze-branch` default from `true` to `false`,
+since Phase 2 makes the `lock_branch` freeze redundant — repos must reach Phase 2 before that
+default flip lands, or they'd briefly have neither guard.
+
+# Citations
+
+[1] [docs/AUTOMATED_RELEASE.md § Release lock gate](/../docs/AUTOMATED_RELEASE.md)

--- a/.okf/workflows/release.md
+++ b/.okf/workflows/release.md
@@ -1,0 +1,34 @@
+---
+type: Workflow
+title: Release (of release-github-actions itself)
+description: On a published GitHub release of this repo, fast-forwards the v1 branch and pins internal @master refs to the release SHA.
+resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/release.yml
+tags: [workflow, release, self-hosting, v1-pinning]
+timestamp: 2026-07-15T00:00:00Z
+---
+
+# Overview
+
+Triggered on `release: [published]`. Checks out the `v${MAJOR}` version branch (e.g. `v1`),
+`git reset --hard`s it to the release tag, then rewrites every internal `@master` reference in
+`action.yml` files and `automated-release.yml` to the exact release commit SHA via `sed`, commits,
+and `git push --force-with-lease`.
+
+This is what makes the [Golden Architecture](/decisions/golden-architecture.md)'s "`@master` on
+master, frozen SHA on `v1`" split work: source on `master` always references siblings as
+`@master` so tests exercise the latest code, while `v1` becomes a self-consistent frozen
+snapshot with no floating refs — consumers pin `@v1` and get exactly what was tested at release
+time.
+
+# Known fragility
+
+Per [risk: release.yml force-push + sed rewrite](/risks/release-yml-fragility.md): the `sed`
+only rewrites `@master` (an internal `@v1` reference is silently left unpinned — see
+[risk: internal @v1 rule violation](/risks/internal-v1-violation.md)); there's no post-sed
+assertion that zero `@master` refs remain; `--force-with-lease` failing leaves `v1` silently
+stale; and `git commit ... || true` swallows all commit failures as "nothing changed."
+
+# Citations
+
+[1] [CLAUDE.md § Golden Architecture](/../CLAUDE.md)
+[2] [docs/ARCHITECTURE_REVIEW.md § 4.4](/../docs/ARCHITECTURE_REVIEW.md)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This is a collection of reusable GitHub Actions for automating SonarSource analyzer releases. Actions handle Jira integration (tickets, versions, release notes), GitHub releases, cross-repository updates, and Slack notifications.
 
+## Knowledge Bundle (.okf)
+
+This repository has an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) knowledge
+bundle at `.okf/` — concept-per-file notes on every action, workflow, shared module, and
+architectural decision, plus a `risks/` directory capturing known reliability/testability gaps
+from the 2026-07-14 architecture review. Consult `.okf/index.md` before non-trivial work in this
+repo, and keep it in sync: when adding/removing/renaming an action or workflow, or making a
+decision worth remembering, update or add the corresponding concept file (see the `okf` skill).
+
 ## Jira Project
 
 Related Jira tickets for this project are tracked in the **GHA** (GitHub Automation) project. When available, use the Jira MCP to access ticket details (e.g., `GHA-123`).


### PR DESCRIPTION
## Problem

There's no single, browsable map of what this repo's 22 actions and 5 workflows do, how they
depend on each other, or which architectural decisions (Golden Architecture, per-action Vault
blocks, env-var injection guard, SHA-pinning) govern changes to them. That context currently
lives split across READMEs, CLAUDE.md, and the standalone `docs/ARCHITECTURE_REVIEW.md` — with
no cross-links between them.

## Approach

Represent the repo as an [OKF](https://github.com/GoogleCloudPlatform/knowledge-catalog) v0.1
knowledge bundle: one concept file per action/workflow/decision/risk, cross-linked, validated
against the spec.

| Question | Decision |
|---|---|
| Where does the bundle live? | `.okf/` at repo root, per the skill's default convention |
| How to organize concepts? | By kind: `actions/`, `workflows/`, `shared/`, `decisions/`, `risks/` — mirrors the repo's own directory split |
| What to do with `docs/ARCHITECTURE_REVIEW.md`'s findings? | Distill each into its own `risks/*.md` concept (14 total) rather than one large doc, so individual findings can be linked from the action/workflow they affect |
| How does Claude Code discover it? | Add a short "Knowledge Bundle (.okf)" section to CLAUDE.md pointing at `.okf/index.md`, with an instruction to keep it in sync going forward |

## Implementation

Added 48 concept files (22 actions, 5 workflows, 1 shared module, 5 decisions, 14 risks) plus
6 `index.md` files and a root `log.md`, all under `.okf/`. Updated `CLAUDE.md` with a pointer
section. No new abstractions or dependencies — plain markdown + YAML frontmatter per the OKF
spec.

## Tests

N/A — this is a documentation-only change (no `action.yml`, workflow, or script edits).

## Test plan

- [x] `okf_validate.py .okf --strict` — 0 errors, only tolerated broken-link warnings to files outside `.okf/` (README.md, CLAUDE.md, docs/)
- [x] Verified every `.okf/*.md` file ends with a trailing newline
- [x] Confirmed `docs/ARCHITECTURE_REVIEW.md` (pre-existing untracked file) is excluded from this PR — it's separate, unrelated work