### PR TITLE
GHA-388 Send release announcements to Code Quality leads Slack

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1106,7 +1106,7 @@ jobs:
         if: ${{ always() && inputs.code-quality-leads-slack-notification && needs.publish-github-release.result == 'success' && needs.publish-github-release.outputs.github-release-url != '' }}
         uses: SonarSource/release-github-actions/slack-message@master
         with:
-          channel: "C0ANR83KA2W"
+          channel: "C0ANR83KA2W"  #team-code-quality-pm-em-lead
           message-markdown: >-
             :tada: **${{ inputs.project-name }}** ${{ needs.prepare-release.outputs.release-version }} has been **released** —
             [Release notes](${{ needs.publish-github-release.outputs.github-release-url }})

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1108,5 +1108,5 @@ jobs:
         with:
           channel: "C0ANR83KA2W"
           message-markdown: >-
-            **${{ inputs.project-name }}** ${{ needs.prepare-release.outputs.release-version }} has been **released** —
+            :tada: **${{ inputs.project-name }}** ${{ needs.prepare-release.outputs.release-version }} has been **released** —
             [Release notes](${{ needs.publish-github-release.outputs.github-release-url }})

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -180,6 +180,11 @@ on:
         description: "Slack channel for notifications"
         required: false
         type: string
+      code-quality-leads-slack-notification:
+        description: "Send the final release summary to the Code Quality PM/EM leads Slack channel"
+        required: false
+        type: boolean
+        default: true
       issue-categories:
         description: "Jira issue categories to include in the release notes"
         required: false
@@ -1095,4 +1100,11 @@ jobs:
         uses: SonarSource/release-github-actions/slack-message@master
         with:
           channel: ${{ inputs.slack-channel }}
+          message-markdown: ${{ steps.create-message.outputs.message }}
+
+      - name: Post Summary to Code Quality Leads Slack
+        if: ${{ always() && steps.create-message.outcome == 'success' && inputs.code-quality-leads-slack-notification }}
+        uses: SonarSource/release-github-actions/slack-message@master
+        with:
+          channel: "C0ANR83KA2W"
           message-markdown: ${{ steps.create-message.outputs.message }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -181,7 +181,7 @@ on:
         required: false
         type: string
       code-quality-leads-slack-notification:
-        description: "Send the final release summary to the Code Quality PM/EM leads Slack channel"
+        description: "Send a release announcement to the Code Quality PM/EM leads Slack channel"
         required: false
         type: boolean
         default: true
@@ -1102,9 +1102,11 @@ jobs:
           channel: ${{ inputs.slack-channel }}
           message-markdown: ${{ steps.create-message.outputs.message }}
 
-      - name: Post Summary to Code Quality Leads Slack
-        if: ${{ always() && steps.create-message.outcome == 'success' && inputs.code-quality-leads-slack-notification }}
+      - name: Post Release Announcement to Code Quality Leads Slack
+        if: ${{ always() && inputs.code-quality-leads-slack-notification && needs.publish-github-release.result == 'success' && needs.publish-github-release.outputs.github-release-url != '' }}
         uses: SonarSource/release-github-actions/slack-message@master
         with:
           channel: "C0ANR83KA2W"
-          message-markdown: ${{ steps.create-message.outputs.message }}
+          message-markdown: >-
+            🎉 **${{ inputs.project-name }} ${{ needs.prepare-release.outputs.release-version }} has been released** —
+            [View release notes](${{ needs.publish-github-release.outputs.github-release-url }})

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -1108,5 +1108,5 @@ jobs:
         with:
           channel: "C0ANR83KA2W"
           message-markdown: >-
-            🎉 **${{ inputs.project-name }} ${{ needs.prepare-release.outputs.release-version }} has been released** —
-            [View release notes](${{ needs.publish-github-release.outputs.github-release-url }})
+            **${{ inputs.project-name }}** ${{ needs.prepare-release.outputs.release-version }} has been **released** —
+            [Release notes](${{ needs.publish-github-release.outputs.github-release-url }})

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,10 +1,11 @@
 # Update Log
 
 ## 2026-07-23
-* **Automated release Slack visibility**: The analyzer release workflow now sends its final
-  summary to the private Code Quality PM/EM leads channel by default. Callers can opt out with
-  `code-quality-leads-slack-notification: false`; the existing configurable Slack destination
-  remains independent.
+* **Automated release Slack visibility**: After creating a GitHub release, the analyzer release
+  workflow now sends a short project/version/release-notes announcement to the private Code
+  Quality PM/EM leads channel by default. Callers can opt out with
+  `code-quality-leads-slack-notification: false`; the existing configurable full-summary Slack
+  destination remains independent.
 
 ## 2026-07-15
 * **Creation**: Established the OKF bundle for this repository — [actions/](/actions/) (22 composite actions), [workflows/](/workflows/) (5 reusable workflows), [shared/](/shared/) (the Jira helper module), [decisions/](/decisions/) (Golden Architecture and security conventions, plus the 2026-07-14 architecture review), and [risks/](/risks/) (14 individual findings distilled from [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)).

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,4 +1,10 @@
 # Update Log
 
+## 2026-07-23
+* **Automated release Slack visibility**: The analyzer release workflow now sends its final
+  summary to the private Code Quality PM/EM leads channel by default. Callers can opt out with
+  `code-quality-leads-slack-notification: false`; the existing configurable Slack destination
+  remains independent.
+
 ## 2026-07-15
 * **Creation**: Established the OKF bundle for this repository — [actions/](/actions/) (22 composite actions), [workflows/](/workflows/) (5 reusable workflows), [shared/](/shared/) (the Jira helper module), [decisions/](/decisions/) (Golden Architecture and security conventions, plus the 2026-07-14 architecture review), and [risks/](/risks/) (14 individual findings distilled from [docs/ARCHITECTURE_REVIEW.md](/../docs/ARCHITECTURE_REVIEW.md)).

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -3,8 +3,8 @@ type: Reusable Workflow
 title: Automated Release (analyzer path)
 description: Orchestrates the full end-to-end analyzer release across Jira, GitHub, and downstream integration repos.
 resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/automated-release.yml
-tags: [workflow, release, orchestrator, jira, github-release]
-timestamp: 2026-07-15T00:00:00Z
+tags: [workflow, release, orchestrator, jira, github-release, slack]
+timestamp: 2026-07-23T00:00:00Z
 ---
 
 # Overview
@@ -72,7 +72,8 @@ Key inputs (selected — full list in the action README): `jira-project-key`, `p
 `sqc-integration` (default `true`), `sqaa-integration` (runs only when `sqc-integration` is
 also true; silently skipped if not onboarded), `create-slvs-ticket` / `create-slvscode-ticket` /
 `create-sle-ticket` / `create-sli-ticket` / `create-cli-ticket` (default `false`), `verbose`
-(default `false`).
+(default `false`), `code-quality-leads-slack-notification` (default `true`; opt out of the
+final summary sent to the Code Quality PM/EM leads Slack channel).
 
 Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 
@@ -85,6 +86,10 @@ Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 - **Freeze window ends early**: the branch unfreezes right after
   [publish-github-release](/actions/publish-github-release.md), *before* the version-bump PR is
   created — see [release-lock](/workflows/release-lock.md) for how that gap is closed.
+- **Default release visibility**: the final success/failure summary is always sent to the
+  private Code Quality PM/EM leads Slack channel unless the caller sets
+  `code-quality-leads-slack-notification: false`. The destination is fixed in the orchestrator;
+  the existing caller-provided `slack-channel` notification remains independent.
 - This workflow has been the subject of an [architecture review](/decisions/architecture-review-2026-07.md)
   identifying reliability, testability, and observability gaps — see the
   [risks](/risks/index.md) directory.

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -73,7 +73,7 @@ Key inputs (selected — full list in the action README): `jira-project-key`, `p
 also true; silently skipped if not onboarded), `create-slvs-ticket` / `create-slvscode-ticket` /
 `create-sle-ticket` / `create-sli-ticket` / `create-cli-ticket` (default `false`), `verbose`
 (default `false`), `code-quality-leads-slack-notification` (default `true`; opt out of the
-final summary sent to the Code Quality PM/EM leads Slack channel).
+release announcement sent to the Code Quality PM/EM leads Slack channel).
 
 Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 
@@ -86,10 +86,11 @@ Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 - **Freeze window ends early**: the branch unfreezes right after
   [publish-github-release](/actions/publish-github-release.md), *before* the version-bump PR is
   created — see [release-lock](/workflows/release-lock.md) for how that gap is closed.
-- **Default release visibility**: the final success/failure summary is always sent to the
-  private Code Quality PM/EM leads Slack channel unless the caller sets
+- **Default release visibility**: after the GitHub release is created, a short announcement
+  containing the project, released version, and GitHub release-notes link is sent to the private
+  Code Quality PM/EM leads Slack channel unless the caller sets
   `code-quality-leads-slack-notification: false`. The destination is fixed in the orchestrator;
-  the existing caller-provided `slack-channel` notification remains independent.
+  the existing caller-provided full-summary `slack-channel` notification remains independent.
 - This workflow has been the subject of an [architecture review](/decisions/architecture-review-2026-07.md)
   identifying reliability, testability, and observability gaps — see the
   [risks](/risks/index.md) directory.

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -77,7 +77,7 @@ This workflow composes several actions from this repository:
 | `freeze-branch-slack-notification` | When `false`, suppresses Slack notifications for the freeze and unfreeze steps                           | No       | `true`       |
 | `check-releasability`        | When `true`, verifies the releasability status on the branch before proceeding                                  | No       | `true`       |
 | `slack-channel`              | Slack channel to notify when locking/unlocking the branch                                                       | No       | -            |
-| `code-quality-leads-slack-notification` | When `false`, suppresses the final release summary sent to `#team-code-quality-pm-em-lead`              | No       | `true`       |
+| `code-quality-leads-slack-notification` | When `false`, suppresses the release announcement sent to `#team-code-quality-pm-em-lead`                | No       | `true`       |
 | `release-artifacts-public`   | Newline-separated Repox paths from public repositories to attach to the GitHub release                          | No       | -            |
 | `release-artifacts-private`  | Newline-separated Repox paths from private repositories to attach to the GitHub release                         | No       | -            |
 
@@ -162,7 +162,7 @@ jobs:
 - Integration tickets and analyzer update PRs are created only if their respective flags are enabled and prerequisites are met.
 - Summaries:
   - Each job includes a "Summary" step that writes to `$GITHUB_STEP_SUMMARY` only when `verbose: true`.
-  - The final release summary is sent to `#team-code-quality-pm-em-lead` by default. Set `code-quality-leads-slack-notification: false` to opt out.
+  - A short release announcement containing the project, released version, and GitHub release-notes link is sent to `#team-code-quality-pm-em-lead` by default after the GitHub release is created. Set `code-quality-leads-slack-notification: false` to opt out.
 - Permissions and environments are scoped per job to minimize required privileges.
 
 ## Release lock gate

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -77,6 +77,7 @@ This workflow composes several actions from this repository:
 | `freeze-branch-slack-notification` | When `false`, suppresses Slack notifications for the freeze and unfreeze steps                           | No       | `true`       |
 | `check-releasability`        | When `true`, verifies the releasability status on the branch before proceeding                                  | No       | `true`       |
 | `slack-channel`              | Slack channel to notify when locking/unlocking the branch                                                       | No       | -            |
+| `code-quality-leads-slack-notification` | When `false`, suppresses the final release summary sent to `#team-code-quality-pm-em-lead`              | No       | `true`       |
 | `release-artifacts-public`   | Newline-separated Repox paths from public repositories to attach to the GitHub release                          | No       | -            |
 | `release-artifacts-private`  | Newline-separated Repox paths from private repositories to attach to the GitHub release                         | No       | -            |
 
@@ -161,6 +162,7 @@ jobs:
 - Integration tickets and analyzer update PRs are created only if their respective flags are enabled and prerequisites are met.
 - Summaries:
   - Each job includes a "Summary" step that writes to `$GITHUB_STEP_SUMMARY` only when `verbose: true`.
+  - The final release summary is sent to `#team-code-quality-pm-em-lead` by default. Set `code-quality-leads-slack-notification: false` to opt out.
 - Permissions and environments are scoped per job to minimize required privileges.
 
 ## Release lock gate


### PR DESCRIPTION
Part of GHA-388

## Summary

- Send a concise project/version/GitHub-release announcement to the private Code Quality PM/EM leads Slack channel after the GitHub release is created.
- Add the default-enabled `code-quality-leads-slack-notification` input so individual callers can opt out.
- Keep the existing caller-configured full-summary Slack notification independent and document the new behavior in the public docs and knowledge bundle.

## Validation

- Parsed `.github/workflows/automated-release.yml` as YAML.
- Ran `actionlint` successfully after excluding the workflow's pre-existing `branch` required/default warning.
- Verified the default-on input contract, corrected channel ID, successful-release guard, concise message fields, and release-time `v1` SHA pinning behavior.

## Rollout

After merge, a `release-github-actions` release must advance `v1` before existing `@v1` callers inherit this notification. The Slack app also needs membership in the private channel.
