### PR TITLE
GHA-389 Add test workflow for release Slack announcement

### DIFF
--- a/.github/workflows/test-code-quality-release-announcement.yml
+++ b/.github/workflows/test-code-quality-release-announcement.yml
@@ -44,5 +44,5 @@ jobs:
         with:
           channel: "C0BJUJ2TL3H"
           message-markdown: >-
-            🎉 **${{ inputs.project-name || 'SonarJS' }} ${{ inputs.release-version || '13.3.0.43633' }} has been released** —
-            [View release notes](${{ inputs.release-url || 'https://github.com/SonarSource/SonarJS/releases/tag/13.3.0.43633' }})
+            **${{ inputs.project-name || 'SonarJS' }}** ${{ inputs.release-version || '13.3.0.43633' }} has been **released** —
+            [Release notes](${{ inputs.release-url || 'https://github.com/SonarSource/SonarJS/releases/tag/13.3.0.43633' }})

--- a/.github/workflows/test-code-quality-release-announcement.yml
+++ b/.github/workflows/test-code-quality-release-announcement.yml
@@ -1,0 +1,48 @@
+name: Test Code Quality Release Announcement
+
+on:
+  workflow_dispatch:
+    inputs:
+      project-name:
+        description: "Project name shown in the Slack announcement"
+        required: true
+        type: string
+        default: "SonarJS"
+      release-version:
+        description: "Released version shown in the Slack announcement"
+        required: true
+        type: string
+        default: "13.3.0.43633"
+      release-url:
+        description: "GitHub release URL used for the release-notes link"
+        required: true
+        type: string
+        default: "https://github.com/SonarSource/SonarJS/releases/tag/13.3.0.43633"
+  # workflow_dispatch is unavailable until a new workflow exists on the default branch.
+  # Labeling a same-repository PR allows the workflow to be tested before merge.
+  pull_request:
+    types: [labeled]
+
+jobs:
+  send-release-announcement:
+    name: Send Test Release Announcement
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+      github.event.label.name == 'run-release-announcement-test' &&
+      github.event.pull_request.head.repo.full_name == github.repository)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Send Release Announcement
+        uses: ./slack-message
+        with:
+          channel: "C0BJUJ2TL3H"
+          message-markdown: >-
+            🎉 **${{ inputs.project-name || 'SonarJS' }} ${{ inputs.release-version || '13.3.0.43633' }} has been released** —
+            [View release notes](${{ inputs.release-url || 'https://github.com/SonarSource/SonarJS/releases/tag/13.3.0.43633' }})

--- a/.github/workflows/test-code-quality-release-announcement.yml
+++ b/.github/workflows/test-code-quality-release-announcement.yml
@@ -44,5 +44,5 @@ jobs:
         with:
           channel: "C0BJUJ2TL3H"
           message-markdown: >-
-            **${{ inputs.project-name || 'SonarJS' }}** ${{ inputs.release-version || '13.3.0.43633' }} has been **released** —
+            :tada: **${{ inputs.project-name || 'SonarJS' }}** ${{ inputs.release-version || '13.3.0.43633' }} has been **released** —
             [Release notes](${{ inputs.release-url || 'https://github.com/SonarSource/SonarJS/releases/tag/13.3.0.43633' }})


### PR DESCRIPTION
Part of GHA-389

## Summary

- Add a manually dispatchable workflow that previews the Code Quality release announcement in Slack channel `C0BJUJ2TL3H`.
- Use realistic SonarJS defaults matching the production message format: project, released version, and GitHub release-notes link.
- Allow pre-merge testing by applying the `run-release-announcement-test` label to a same-repository PR; fork PRs cannot execute the Slack job.

## Trigger from a PR branch

```shell
gh pr edit --add-label run-release-announcement-test
```

To run it again, remove and then reapply the label. After the workflow exists on `master`, it can also be launched with `gh workflow run test-code-quality-release-announcement.yml` and optional custom inputs.

## Validation

- Parsed the workflow as YAML.
- Ran `actionlint` successfully.
- [Executed the refined-format test successfully](https://github.com/SonarSource/release-github-actions/actions/runs/30004395478), including Vault access, selective Markdown emphasis, payload construction, and Slack `chat.postMessage` delivery to `C0BJUJ2TL3H`.
