### PR TITLE
GHA-392 Add CONTRIBUTING.md and fix stale README development section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing
+
+## Branching
+
+Never commit or push directly to `master`. Always work on a feature branch named
+`<username-prefix>/<feature-name>` (lowercase, hyphen-separated), e.g. `nw/add-slack-notifications`.
+Ask the team for your prefix if you don't have one yet.
+
+PRs are normally tied to a Jira ticket (project **GHA**) referenced in the PR title. If there's
+no ticket, the `.github/PULL_REQUEST_TEMPLATE.md` explains how to let Jira automation create one.
+
+## Repository structure
+
+Each action is a self-contained composite action:
+
+```
+action-name/
+├── action.yml           # composite action definition
+├── README.md            # inputs, outputs, usage
+├── requirements.txt     # Python deps (if applicable)
+├── <script>.py          # implementation
+└── test_<script>.py     # pytest unit tests
+```
+
+See `lock-branch/` for a working example. Python helpers shared by ≥2 actions belong in
+`shared/`, not duplicated per-action — see `shared/jira_common.py`.
+
+When adding a new action:
+1. Follow the structure above.
+2. Add a `README.md` documenting inputs/outputs/usage.
+3. Link it from the table in the root `README.md`.
+4. Add a `test-<action-name>.yml` CI workflow (see "Testing in CI" below) and wire it into
+   `test-all.yml`.
+
+Before writing or editing `action.yml`, read the Security and Golden Architecture sections of
+[CLAUDE.md](CLAUDE.md) — in particular: never interpolate `${{ inputs.x }}` directly into a
+`run:` block (pass it through `env:` instead), and pin non-SonarSource actions to a full commit
+SHA with a version comment.
+
+## Testing locally
+
+Each action is tested independently — there's no root test runner or Makefile.
+
+```bash
+cd <action-name>
+pip install -r requirements.txt
+pip install pytest pytest-cov
+python -m pytest test_*.py -v --cov=<module_name> --cov-report=term-missing
+```
+
+Run a single test:
+
+```bash
+python -m pytest test_<module>.py::TestClassName::test_method_name -v
+```
+
+`shared/` and `test-fixtures/jira/` follow the same pattern.
+
+## Testing in CI
+
+Every action has its own `test-<action-name>.yml` workflow. The standard trigger shape:
+
+```yaml
+on:
+  workflow_call:
+  pull_request:
+    paths:
+      - '<action-name>/**'
+      - '.github/workflows/test-<action-name>.yml'
+  push:
+    branches:
+      - branch-*
+    paths:
+      - '<action-name>/**'
+      - '.github/workflows/test-<action-name>.yml'
+  workflow_dispatch:
+```
+
+This means a PR touching an action's directory (or its own test workflow) automatically runs
+that action's tests. `push` to a `branch-*`-named branch does the same. `test-all.yml` fans out
+to a subset of these workflows via `workflow_call` on every push to `master`, and can also be
+triggered manually.
+
+A few older test workflows deviate slightly from this shape (e.g. broader `push` branch filters)
+— match the pattern of a recently-added action's test workflow when in doubt.
+
+## Releasing this repository
+
+External consumers pin actions to `SonarSource/release-github-actions/<action>@v1`. On `master`,
+every internal reference between sibling actions/workflows uses `@master` instead — never write
+a new internal reference as `@v1`, including in test-script string assertions.
+
+An action's `inputs:`/`outputs:` are its public API — changing them is a breaking change.
+
+Publishing a GitHub Release on this repository triggers `.github/workflows/release.yml`
+(`on: release: types: [published]`), which fast-forwards the `v<major>` branch (e.g. `v1`) to
+the release tag and rewrites every internal `@master` reference to the release commit SHA. No
+separate manual step is needed to update `v1` after a release is published.
+
+This is unrelated to `automated-release.yml`, the reusable workflow this repo *provides* for
+releasing an analyzer — see [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md) for that.
+
+## Further reading
+
+- [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md) — reference for the analyzer release
+  workflow this repo provides.
+- [docs/ARCHITECTURE_REVIEW.md](docs/ARCHITECTURE_REVIEW.md) — known architecture and testing
+  gaps, for anyone doing deeper work on the orchestrator.
+- [.okf/index.md](.okf/index.md) — concept-per-file knowledge bundle covering every action,
+  workflow, and architectural decision in this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ releasing an analyzer — see [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE
 
 - [docs/AUTOMATED_RELEASE.md](docs/AUTOMATED_RELEASE.md) — reference for the analyzer release
   workflow this repo provides.
-- [docs/ARCHITECTURE_REVIEW.md](docs/ARCHITECTURE_REVIEW.md) — known architecture and testing
-  gaps, for anyone doing deeper work on the orchestrator.
+- [.okf/decisions/architecture-review-2026-07.md](.okf/decisions/architecture-review-2026-07.md) —
+  known architecture and testing gaps, for anyone doing deeper work on the orchestrator.
 - [.okf/index.md](.okf/index.md) — concept-per-file knowledge bundle covering every action,
   workflow, and architectural decision in this repo.

--- a/README.md
+++ b/README.md
@@ -204,6 +204,5 @@ Detailed instructions for Claude Code to follow...
 
 ## Development
 
-### Update Action Versions Workflow
-
-The repository includes an `update-action-versions` workflow that creates a pull request to update all internal action references to use a specific commit or the latest version from the master branch. This workflow scans all `action.yml` files in the repository and updates any references to `SonarSource/release-github-actions` actions to point to the specified reference, ensuring consistency across all actions when updates are made to shared components.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to branch, test, and release changes in this
+repository.


### PR DESCRIPTION
## Problem

There is no single place documenting how to branch, test, and release changes in this
repository. The README's "Development" section describes an `update-action-versions` workflow
that was deleted from `master` in commit 58dc1cc (2026-06-26) when the repo switched to
permanent `@master` internal refs pinned to a SHA at release time — that section has been
actively wrong since then.

## Approach

Add a root `CONTRIBUTING.md` covering branching, repo/action structure, local and CI testing,
and the release mechanism (`release.yml` fast-forwarding `v1`). Replace the stale README section
with a pointer to it rather than duplicating content across two files.

| Question | Decision |
|---|---|
| Where should the guide live? | New root `CONTRIBUTING.md` — standard GitHub convention, auto-linked from PR/issue UI, rather than expanding README in place |
| How much detail on known testing/architecture gaps (untested inline shell, no orchestrator test, etc.)? | None — keep this purely procedural; those gaps are already documented in `docs/ARCHITECTURE_REVIEW.md`, linked from the "Further reading" section instead of duplicated |
| Fix the stale README section now or file separately? | Fix now, same PR — it's a one-paragraph replacement and leaving it would mean the new guide and the README point at contradictory descriptions of the release mechanism |

## Implementation

Added `CONTRIBUTING.md` at the repo root; edited `README.md`'s `## Development` section to link
to it instead of describing the deleted workflow. No code or workflow changes — docs only.

## Tests

Docs-only change; no test suite applies. Verified:
- Every command/trigger snippet in `CONTRIBUTING.md` matches an actual file (`lock-branch/`
  test commands, `test-lock-branch.yml`'s trigger shape, `release.yml`'s actual behavior,
  `test-all.yml`'s trigger).
- `grep -n "update-action-versions" README.md` returns no matches after the edit.

## Test plan

- [x] Confirmed no stale references to the deleted workflow remain in README.md
- [x] Read through CONTRIBUTING.md end-to-end for accuracy against source files