### PR TITLE
GHA-395 Include Maintenance issue type in default release notes categories

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -189,7 +189,7 @@ on:
         description: "Jira issue categories to include in the release notes"
         required: false
         type: string
-        default: "Feature,False Positive,False Negative,Bug,Security"
+        default: "Feature,False Positive,False Negative,Bug,Security,Maintenance"
       bump-version:
         description: "Whether to bump the version after the release. If false, the workflow will just output the next version without modifying any files."
         required: false


### PR DESCRIPTION
## Problem

The automated release workflow builds GitHub release notes from Jira tickets via an inclusion allowlist (`issue-categories` input). The default list excludes the `Maintenance` issue type, so bot tickets, version-bump tickets, and other maintenance work filed under that type are silently dropped from release notes even though they were part of the release.

## Approach

`Maintenance` is a standard issue type across this Jira taxonomy (confirmed against GHA, SONARSEC, CLOUDSEC, and AGENTSEC — all analyzer-style projects share the same type set: Initiative, Epic, Feature, False Positive, False Negative, Maintenance, Bug, Security, Sub-task). Adding it to the existing default allowlist is the minimal fix — no change needed to the underlying allowlist mechanism, the `get-jira-release-notes` action, or its Python script, since `automated-release.yml`'s `issue-categories` input is the one that actually drives the default for the production automated-release flow.

## Implementation

One-line change in `.github/workflows/automated-release.yml`: the `issue-categories` input default goes from `"Feature,False Positive,False Negative,Bug,Security"` to `"Feature,False Positive,False Negative,Bug,Security,Maintenance"`.

## Tests

No existing test asserts the old `automated-release.yml` default value directly — `test-get-jira-release-notes.yml` tests the `get-jira-release-notes` action's own (separate) default, and already has a job (`test-custom-issue-categories`) proving Maintenance can be included via an explicit list, so no test changes were needed.

## Test plan

- [x] Grepped `.github/workflows/` for the old default string — no other references found
- [x] Validated YAML syntax of `automated-release.yml` after the change