### PR TITLE
GHA-400 Allow to create an SLCORE ticket on release

### DIFF
--- a/.claude/skills/automated-release-setup/SKILL.md
+++ b/.claude/skills/automated-release-setup/SKILL.md
@@ -21,11 +21,12 @@ Ask the user for the following details using AskUserQuestion:
 4. **PM Email**: Product Manager email address
 5. **Slack Channel**: Check the existing `release.yml` for `slackChannel` value first - reuse it if present, otherwise ask the user
 6. **Build System**: Maven (pom.xml) or Gradle (gradle.properties)
-7. **SonarLint Integration**: Whether to create integration tickets for SonarLint IDE plugins:
-   - **SLVS** (SonarLint for Visual Studio)
-   - **SLVSCode** (SonarLint for VS Code)
-   - **SLE** (SonarLint for Eclipse)
-   - **SLI** (SonarLint for IntelliJ)
+7. **SonarQube for IDE Integration**: Whether to create integration tickets for SonarQube for IDE:
+   - **SLVS** (SonarQube for Visual Studio)
+   - **SLVSCODE** (SonarQube for VS Code)
+   - **SLCORE** (SonarLint Core)
+   - **SLE** (SonarQube for Eclipse)
+   - **SLI** (SonarQube for IntelliJ)
 8. **CLI Integration**: Whether to create an integration ticket for the SonarQube CLI scanner.
 9. **Version Bump**: Whether the automated release workflow should bump the project version after the release (i.e., prepare the next development iteration). If yes, also ask:
    - **Bump Version PR Labels**: Optional comma-separated list of labels to apply to the version bump pull request (e.g., `update-next-dev,skip-qa`). Leave empty if no labels are needed.
@@ -78,7 +79,7 @@ Remind the user of these prerequisites and **ask for confirmation** using AskUse
 
 Create only the `automated-release` workflow file (using the detected extension from Step 1c). **Do not create a separate `bump-versions` workflow** — version bumping is handled directly by the reusable workflow when `bump-version: true` is passed.
 
-#### 3.1 Create `automated-release{EXT}` (standard, no SonarLint, no version bump)
+#### 3.1 Create `automated-release{EXT}` (standard, no SonarQube for IDE integration, no version bump)
 
 ```yaml
 name: Automated Release
@@ -147,7 +148,7 @@ jobs:
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
 ```
 
-#### 3.2 Create `automated-release{EXT}` (standard, no SonarLint, **with version bump**)
+#### 3.2 Create `automated-release{EXT}` (standard, no SonarQube for IDE integration, **with version bump**)
 
 When the user wants version bumping, add `bump-version: true` (and optionally `bump-version-pr-labels`) to the `with:` block:
 
@@ -220,7 +221,7 @@ jobs:
       bump-version-pr-labels: "${BUMP_VERSION_PR_LABELS}"  # omit this line if no labels
 ```
 
-#### 3.3 Create `automated-release{EXT}` (with SonarLint integration, no version bump)
+#### 3.3 Create `automated-release{EXT}` (with SonarQube for IDE integration, no version bump)
 
 ```yaml
 name: Automated Release
@@ -232,7 +233,7 @@ on:
         required: true
         type: string
       sq-ide-short-description:
-        description: "Short description for the SonarLint IDE tickets (leave empty to skip IDE tickets)"
+        description: "Short description for the SonarQube for IDE tickets (leave empty to skip IDE tickets)"
         required: false
         type: string
       sqc-integration:
@@ -244,19 +245,23 @@ on:
         type: boolean
         default: true
       slvs-integration:
-        description: "Create SLVS ticket (SonarLint for Visual Studio)"
+        description: "Create SLVS ticket (SonarQube for Visual Studio)"
         type: boolean
         default: false
       slvscode-integration:
-        description: "Create SLVSCode ticket (SonarLint for VS Code)"
+        description: "Create SLVSCODE ticket (SonarQube for VS Code)"
+        type: boolean
+        default: false
+      slcore-integration:
+        description: "Create SLCORE ticket (SonarLint Core)"
         type: boolean
         default: false
       sle-integration:
-        description: "Create SLE ticket (SonarLint for Eclipse)"
+        description: "Create SLE ticket (SonarQube for Eclipse)"
         type: boolean
         default: false
       sli-integration:
-        description: "Create SLI ticket (SonarLint for IntelliJ)"
+        description: "Create SLI ticket (SonarQube for IntelliJ)"
         type: boolean
         default: false
       branch:
@@ -303,6 +308,7 @@ jobs:
       sqs-integration: ${{ github.event.inputs.sqs-integration == 'true' }}
       create-slvs-ticket: ${{ github.event.inputs.slvs-integration == 'true' }}
       create-slvscode-ticket: ${{ github.event.inputs.slvscode-integration == 'true' }}
+      create-slcore-ticket: ${{ github.event.inputs.slcore-integration == 'true' }}
       create-sle-ticket: ${{ github.event.inputs.sle-integration == 'true' }}
       create-sli-ticket: ${{ github.event.inputs.sli-integration == 'true' }}
       sq-ide-short-description: ${{ github.event.inputs.sq-ide-short-description }}
@@ -314,11 +320,11 @@ jobs:
       is-draft-release: ${{ github.event.inputs.dry-run == 'true' }}
 ```
 
-#### 3.4 Create `automated-release{EXT}` (with SonarLint integration **and** version bump)
+#### 3.4 Create `automated-release{EXT}` (with SonarQube for IDE integration **and** version bump)
 
-Add `bump-version: true` (and optionally `bump-version-pr-labels`) to the SonarLint variant's `with:` block, same as in 3.2.
+Add `bump-version: true` (and optionally `bump-version-pr-labels`) to the SonarQube for IDE variant's `with:` block, same as in 3.2.
 
-#### 3.5 Create `automated-release{EXT}` (with SQ-CLI integration, no version bump, no SonarLint integration)
+#### 3.5 Create `automated-release{EXT}` (with SQ-CLI integration, no version bump, no SonarQube for IDE integration)
 
 ```yaml
 name: Automated Release
@@ -626,10 +632,10 @@ Remind user of post-release tasks:
 - Update integration ticket statuses in Jira
 - Set fix versions on the SONAR ticket
 
-**If SonarLint integration is enabled:**
-- Monitor the SLVS, SLVSCode, SLE, and/or SLI tickets created in Jira
-- Coordinate with IDE teams for integration timelines
-- Verify analyzer compatibility with SonarLint versions
+**If SonarQube for IDE integration is enabled:**
+- Monitor the SLCORE, SLVS, SLVSCODE, SLE, and/or SLI tickets created in Jira
+- Coordinate with the relevant SonarQube for IDE teams for integration timelines
+- Verify analyzer compatibility with SonarQube for IDE versions
 
 ### Advanced Options
 
@@ -640,26 +646,27 @@ Mention these optional configurations if relevant:
 - **Disable releasability check**: `check-releasability: false`
 - **Attach release artifacts**: `release-artifacts-public`, `release-artifacts-private` — download artifacts from Repox and attach them to the GitHub release draft. Provide full Artifactory paths including the repo name, with `{version}` as placeholder for the release version.
 
-### SonarLint Integration Details
+### SonarQube for IDE Integration Details
 
-When SonarLint integration is enabled, the workflow creates Jira tickets for the relevant IDE teams:
+When SonarQube for IDE integration is enabled, the workflow creates Jira tickets for SLCORE and supported IDEs:
 
 | Input | Jira Project | Description |
 |-------|--------------|-------------|
-| `create-slvs-ticket` | SLVS | SonarLint for Visual Studio |
-| `create-slvscode-ticket` | SLVSCODE | SonarLint for VS Code |
-| `create-sle-ticket` | SLE | SonarLint for Eclipse |
-| `create-sli-ticket` | SLI | SonarLint for IntelliJ |
+| `create-slvs-ticket` | SLVS | SonarQube for Visual Studio |
+| `create-slvscode-ticket` | SLVSCODE | SonarQube for VS Code |
+| `create-slcore-ticket` | SLCORE | SonarLint Core |
+| `create-sle-ticket` | SLE | SonarQube for Eclipse |
+| `create-sli-ticket` | SLI | SonarQube for IntelliJ |
 
-The `sq-ide-short-description` input is used as the description for all IDE tickets. This should describe what changes are relevant for IDE integrations (e.g., "New rules for X", "Updated analysis engine", "Breaking API changes").
+The `sq-ide-short-description` input is used as the description for all SonarQube for IDE tickets. This should describe what changes are relevant for these integrations (e.g., "New rules for X", "Updated analysis engine", "Breaking API changes").
 
-**When to enable SonarLint integration:**
-- The analyzer is used by SonarLint (standalone analysis)
+**When to enable SonarQube for IDE integration:**
+- The analyzer is used by SonarQube for IDE (standalone analysis)
 - New rules or rule changes that affect IDE users
 - Breaking changes in the analyzer API
 - Performance improvements relevant to IDE analysis
 
-**Note:** Not all analyzers are integrated with SonarLint. Check with the IDE teams if unsure whether your analyzer requires SonarLint integration tickets.
+**Note:** Not all analyzers are integrated with SonarQube for IDE. Check with the relevant SonarQube for IDE teams if unsure whether your analyzer requires integration tickets.
 
 ### CLI Integration Details
 

--- a/.claude/skills/devex-release-setup/SKILL.md
+++ b/.claude/skills/devex-release-setup/SKILL.md
@@ -4,8 +4,7 @@ description: >
   Use this skill whenever the user asks to "set up Development Experience release workflow",
   "configure DevEx release automation", "add full-release workflow", "add release
   automation using ide-automated-release", or any variation of setting up the
-  automated release workflow for a SonarSource Development Experience project (SonarLint
-  Core, SonarLint for IntelliJ, SonarLint for Eclipse, SonarLint for VS Code, etc.).
+  automated release workflow for a SonarSource Development Experience project (SonarLint Core, SonarQube for IntelliJ, SonarQube for Eclipse, SonarQube for VS Code, etc.).
   This skill gathers project details and creates the necessary workflow file.
 ---
 
@@ -62,7 +61,7 @@ Use AskUserQuestion to ask the user. Batch independent questions together.
 
 **Always ask (Batch 1)**:
 - **Jira Project Key**: The Jira project key (e.g., `SLCORE`, `SLI`, `SLVS`, `SLE`).
-- **Project Name**: Human-readable project name used in Jira REL tickets (e.g., `SonarLint Core`, `SonarLint for IntelliJ`).
+- **Project Name**: Human-readable project name used in Jira REL tickets (e.g., `SonarLint Core`, `SonarQube for IntelliJ`).
 
 **Ask only what wasn't auto-detected (Batch 2)**:
 - **Slack channel**: Only ask if not found in existing workflows. Present the default `squad-ide-slcore-bots` as an option.

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -102,6 +102,11 @@ on:
         required: false
         type: boolean
         default: false
+      create-slcore-ticket:
+        description: "Create SLCORE integration ticket"
+        required: false
+        type: boolean
+        default: false
       create-sle-ticket:
         description: "Create SLE integration ticket"
         required: false
@@ -736,13 +741,13 @@ jobs:
         run: echo "Skipped — release-lock status reset requires statuses:write on the lock token"
 
   # This step creates integration tickets in various Jira projects based on the inputs provided.
-  # It creates tickets for SLVS, SLVSCODE, SLE, SLI, SQC, and SQS as specified.
+  # It creates tickets for SLVS, SLVSCODE, SLCORE, SLE, SLI, CLI, SQC, and SQS as specified.
   # It outputs the integration ticket keys for SQC and SQS for further use.
   create-integration-tickets:
     name: Create Integration Tickets
     needs: [ prepare-release, publish-github-release, create-release-ticket ]
     if: |
-      (inputs.create-slvs-ticket || inputs.create-slvscode-ticket || inputs.create-sle-ticket || inputs.create-sli-ticket || inputs.create-cli-ticket || inputs.sqc-integration || inputs.sqs-integration) && 
+      (inputs.create-slvs-ticket || inputs.create-slvscode-ticket || inputs.create-slcore-ticket || inputs.create-sle-ticket || inputs.create-sli-ticket || inputs.create-cli-ticket || inputs.sqc-integration || inputs.sqs-integration) &&
       !cancelled() && 
       needs.prepare-release.result == 'success' &&
       needs.publish-github-release.result == 'success' &&
@@ -777,6 +782,17 @@ jobs:
           release-version: ${{ needs.prepare-release.outputs.release-version }}
           release-ticket-key: ${{ needs.create-release-ticket.outputs.release-ticket-key }}
           target-jira-project: "SLVSCODE"
+          ticket-description: ${{ inputs.sq-ide-short-description != '' && inputs.sq-ide-short-description || inputs.short-description }}
+          jira-release-url: ${{ needs.prepare-release.outputs.jira-release-url }}
+
+      - name: Create SLCORE Ticket
+        if: ${{ inputs.create-slcore-ticket }}
+        uses: SonarSource/release-github-actions/create-integration-ticket@master
+        with:
+          plugin-name: ${{ inputs.plugin-name }}
+          release-version: ${{ needs.prepare-release.outputs.release-version }}
+          release-ticket-key: ${{ needs.create-release-ticket.outputs.release-ticket-key }}
+          target-jira-project: "SLCORE"
           ticket-description: ${{ inputs.sq-ide-short-description != '' && inputs.sq-ide-short-description || inputs.short-description }}
           jira-release-url: ${{ needs.prepare-release.outputs.jira-release-url }}
 
@@ -855,6 +871,7 @@ jobs:
           PLUGIN_NAME: ${{ inputs.plugin-name }}
           CREATE_SLVS_TICKET: ${{ inputs.create-slvs-ticket == true && 'true' || 'false' }}
           CREATE_SLVSCODE_TICKET: ${{ inputs.create-slvscode-ticket == true && 'true' || 'false' }}
+          CREATE_SLCORE_TICKET: ${{ inputs.create-slcore-ticket == true && 'true' || 'false' }}
           CREATE_SLE_TICKET: ${{ inputs.create-sle-ticket == true && 'true' || 'false' }}
           CREATE_SLI_TICKET: ${{ inputs.create-sli-ticket == true && 'true' || 'false' }}
           CREATE_CLI_TICKET: ${{ inputs.create-cli-ticket == true && 'true' || 'false' }}
@@ -870,6 +887,7 @@ jobs:
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           if [ "$CREATE_SLVS_TICKET" = "true" ]; then echo "- SLVS ticket created." >> $GITHUB_STEP_SUMMARY; fi
           if [ "$CREATE_SLVSCODE_TICKET" = "true" ]; then echo "- SLVSCODE ticket created." >> $GITHUB_STEP_SUMMARY; fi
+          if [ "$CREATE_SLCORE_TICKET" = "true" ]; then echo "- SLCORE ticket created." >> $GITHUB_STEP_SUMMARY; fi
           if [ "$CREATE_SLE_TICKET" = "true" ]; then echo "- SLE ticket created." >> $GITHUB_STEP_SUMMARY; fi
           if [ "$CREATE_SLI_TICKET" = "true" ]; then echo "- SLI ticket created." >> $GITHUB_STEP_SUMMARY; fi
           if [ "$CREATE_CLI_TICKET" = "true" ]; then echo "- CLI ticket created." >> $GITHUB_STEP_SUMMARY; fi

--- a/.okf/actions/create-integration-ticket.md
+++ b/.okf/actions/create-integration-ticket.md
@@ -4,13 +4,13 @@ title: Create Integration Ticket
 description: Creates a Jira integration ticket with a custom summary and links it to an existing release ticket.
 resource: https://github.com/SonarSource/release-github-actions/tree/master/create-integration-ticket
 tags: [action, jira, integration-ticket]
-timestamp: 2026-07-15T00:00:00Z
+timestamp: 2026-08-05T00:00:00Z
 ---
 
 # Overview
 
 Python-based action that connects to Jira, validates the release ticket exists, creates a new
-ticket in a target Jira project (e.g. `SLVS`, `SLVSCODE`, `SLE`, `SLI`, `SQS`, `SQC`), sets its
+ticket in a target Jira project (e.g. `SLCORE`, `SLVS`, `SLVSCODE`, `SLE`, `SLI`, `SQS`, `SQC`), sets its
 description, and links it to the release ticket. Used by
 [automated-release](/workflows/automated-release.md) to fan out IDE/CLI integration tickets
 after a release.

--- a/.okf/risks/hardcoded-integration-targets.md
+++ b/.okf/risks/hardcoded-integration-targets.md
@@ -3,14 +3,14 @@ type: Risk
 title: SonarSource-specific hardcoding makes "reusable" aspirational
 description: Jira project keys and custom field IDs for integration targets are string literals baked into the orchestrator, not configuration.
 tags: [risk, maintainability, hardcoding, p2]
-timestamp: 2026-07-14T00:00:00Z
+timestamp: 2026-08-05T00:00:00Z
 ---
 
 # Observation
 
-Project keys `SLVS`, `SLVSCODE`, `SLE`, `SLI`, `CLI`, `SC`, `SONAR` are hardcoded as string
+Project keys `SLVS`, `SLVSCODE`, `SLCORE`, `SLE`, `SLI`, `CLI`, `SC`, `SONAR` are hardcoded as string
 literals in the fan-out steps of [automated-release](/workflows/automated-release.md)
-(`:763`–`:841`). Adding a new integration target means editing the 1,100-line orchestrator, not
+(`:766`–`:865`). Adding a new integration target means editing the 1,100-line orchestrator, not
 passing config. Custom field IDs (see [shared/jira_common.py](/shared/jira-common.md)) and the
 KTLO epic notion are SonarSource-tenant constants baked into ostensibly "reusable" code.
 

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -4,7 +4,7 @@ title: Automated Release (analyzer path)
 description: Orchestrates the full end-to-end analyzer release across Jira, GitHub, and downstream integration repos.
 resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/automated-release.yml
 tags: [workflow, release, orchestrator, jira, github-release, slack]
-timestamp: 2026-07-23T00:00:00Z
+timestamp: 2026-08-05T00:00:00Z
 ---
 
 # Overview
@@ -42,7 +42,7 @@ create-release-ticket   publish-github-release
                │
        ┌───────┴────────────────────┐
        ▼                            ▼
-  bump-version                create-integration-tickets (SLVS/SLE/SLI/SQS/SQC/...)
+  bump-version                create-integration-tickets (SLCORE/SLVS/SLE/SLI/SQS/...)
   (opens version-bump PR)            │
                                      ▼
                             update-analyzer PRs (sonar-enterprise, sonar-plugins-deployer)
@@ -71,7 +71,8 @@ Key inputs (selected — full list in the action README): `jira-project-key`, `p
 (default `true`), `check-releasability` (default `true`), `sqs-integration` /
 `sqc-integration` (default `true`), `sqaa-integration` (runs only when `sqc-integration` is
 also true; silently skipped if not onboarded), `create-slvs-ticket` / `create-slvscode-ticket` /
-`create-sle-ticket` / `create-sli-ticket` / `create-cli-ticket` (default `false`), `verbose`
+`create-slcore-ticket` / `create-sle-ticket` / `create-sli-ticket` / `create-cli-ticket`
+(default `false`), `verbose`
 (default `false`), `code-quality-leads-slack-notification` (default `true`; opt out of the
 release announcement sent to the Code Quality PM/EM leads Slack channel).
 

--- a/.okf/workflows/ide-automated-release.md
+++ b/.okf/workflows/ide-automated-release.md
@@ -1,16 +1,17 @@
 ---
 type: Reusable Workflow
 title: IDE Automated Release (DevEx path)
-description: Reusable release orchestration for SonarLint / Development Experience projects, separate from the analyzer path.
+description: Reusable release orchestration for SonarQube for IDE / Development Experience projects, separate from the analyzer path.
 resource: https://github.com/SonarSource/release-github-actions/blob/master/.github/workflows/ide-automated-release.yml
-tags: [workflow, release, orchestrator, devex, sonarlint]
-timestamp: 2026-07-15T00:00:00Z
+tags: [workflow, release, orchestrator, devex, sonarqube-for-ide]
+timestamp: 2026-08-05T00:00:00Z
 ---
 
 # Overview
 
 Reusable `workflow_call` workflow for Development Experience projects (SonarLint Core,
-SonarLint for IntelliJ, SonarLint for Eclipse, SonarLint for VS Code, etc.), set up via the
+SonarQube for IntelliJ, SonarQube for Eclipse, SonarQube for VS Code, etc.),
+set up via the
 `devex-release-setup` Claude Code skill. Explicitly out of scope for the
 [architecture review](/decisions/architecture-review-2026-07.md), which covers only the
 analyzer path ([automated-release](/workflows/automated-release.md)). Roughly a fifth the size

--- a/.okf/workflows/index.md
+++ b/.okf/workflows/index.md
@@ -1,7 +1,7 @@
 # Workflows
 
 * [automated-release](automated-release.md) - the analyzer release orchestrator; the main entry point for this repo.
-* [ide-automated-release](ide-automated-release.md) - the DevEx/IDE (SonarLint) release orchestrator.
+* [ide-automated-release](ide-automated-release.md) - the DevEx/IDE (SonarQube for IDE) release orchestrator.
 * [abd-automated-release](abd-automated-release.md) - a distinct release-orchestration variant.
 * [release-lock](release-lock.md) - required-status-check gate that blocks other PRs while a version-bump PR is open.
 * [release](release.md) - this repo's own release workflow; fast-forwards `v1` and pins internal refs.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ manually via `workflow_dispatch` from the analyzer repo.
 │           ┌────────────┴──────────────────┐                                  │
 │           ▼                               ▼                                   │
 │  bump-version                   create-integration-tickets                    │
-│  (opens version-bump PR)        (SLVS / SLE / SLI / SQS / SQC / ...)        │
+│  (opens version-bump PR)        (SLCORE / SLVS / SLE / SLI / SQS / ...)       │
 │           │                               │                                   │
 │           │                               ▼                                   │
 │           │                     update-analyzer PRs                           │
@@ -111,7 +111,7 @@ This repository includes Claude Code skills for automating common tasks related 
 |-------|-------------|
 | [automated-release-setup](.claude/skills/automated-release-setup/) | Set up automated release workflow for SonarSource analyzer projects |
 | [automated-release-run](.claude/skills/automated-release-run/) | Trigger and monitor an automated release end-to-end, including merging the resulting pull requests |
-| [devex-release-setup](.claude/skills/devex-release-setup/) | Set up automated release workflow for SonarSource Development Experience projects (SonarLint Core, SonarLint for IntelliJ, etc.) |
+| [devex-release-setup](.claude/skills/devex-release-setup/) | Set up automated release workflow for SonarSource Development Experience projects (SonarLint Core, SonarQube for IntelliJ, etc.) |
 
 ### Usage
 
@@ -132,7 +132,7 @@ Once the workflow is set up, trigger and monitor an actual release end-to-end:
 
 Or use the slash command: `/automated-release-run <repo-name>`
 
-For Development Experience projects (SonarLint Core, SonarLint for IntelliJ, etc.):
+For Development Experience projects (SonarLint Core, SonarQube for IntelliJ, etc.):
 
 - "Set up Development Experience release workflow"
 - "Add full-release workflow using ide-automated-release"

--- a/create-jira-release-ticket/README.md
+++ b/create-jira-release-ticket/README.md
@@ -32,7 +32,7 @@ This action depends on:
 | `documentation-status` | Status of the documentation                                                                                                                                                                                     | No       | `N/A`   |
 | `rule-props-changed`   | Whether rule properties have changed (`Yes` or `No`)                                                                                                                                                            | No       | `No`    |
 | `jira-release-url`     | The URL to the Jira release notes page. Can also be set via `JIRA_RELEASE_URL` environment variable. If neither is provided, the action will automatically fetch the release URL using `get-jira-release-notes` | No       | -       |
-| `sonarlint-changelog`  | The SonarLint changelog content                                                                                                                                                                                 | No       | -       |
+| `sonarlint-changelog`  | The SonarQube for IDE changelog content                                                                                                                                                                         | No       | -       |
 | `start-progress`       | Whether to start progress on the release ticket after creation                                                                                                                                                  | No       | `false` |
 
 *Either the input or corresponding environment variable must be provided for jira-project-key.
@@ -146,13 +146,13 @@ The action uses a Python script that:
 
 The action populates the following Jira custom fields:
 
-| Field                   | Custom Field ID   | Source Input           |
-|-------------------------|-------------------|------------------------|
-| Short Description       | customfield_10146 | `short-description`    |
-| Link to Release Notes   | customfield_10145 | `jira-release-url`     |
-| Documentation Status    | customfield_10147 | `documentation-status` |
-| Rule Properties Changed | customfield_11263 | `rule-props-changed`   |
-| SonarLint Changelog     | customfield_11264 | `sonarlint-changelog`  |
+| Field                       | Custom Field ID   | Source Input           |
+|-----------------------------|-------------------|------------------------|
+| Short Description           | customfield_10146 | `short-description`    |
+| Link to Release Notes       | customfield_10145 | `jira-release-url`     |
+| Documentation Status        | customfield_10147 | `documentation-status` |
+| Rule Properties Changed     | customfield_11263 | `rule-props-changed`   |
+| SonarQube for IDE Changelog | customfield_11264 | `sonarlint-changelog`  |
 
 ## Notes
 

--- a/create-jira-release-ticket/action.yml
+++ b/create-jira-release-ticket/action.yml
@@ -26,7 +26,7 @@ inputs:
   jira-release-url:
     description: 'The URL to the Jira release notes page. Required if JIRA_RELEASE_URL env var is not set.'
   sonarlint-changelog:
-    description: 'The SonarLint changelog content.'
+    description: 'The SonarQube for IDE changelog content.'
     default: ''
   start-progress:
     description: 'Whether to start progress on the release ticket.'

--- a/create-jira-release-ticket/create_release_ticket.py
+++ b/create-jira-release-ticket/create_release_ticket.py
@@ -60,7 +60,7 @@ def main():
     parser.add_argument("--rule-props-changed", default="No", choices=['Yes', 'No'],
                         help="Whether rule properties have changed.")
     parser.add_argument("--jira-release-url", default="", help="The URL to the Jira release notes page.")
-    parser.add_argument("--sonarlint-changelog", default="", help="The SonarLint changelog content.")
+    parser.add_argument("--sonarlint-changelog", default="", help="The SonarQube for IDE changelog content.")
     parser.add_argument("--due-date", default="", help="Due date of the release, for example '2029-12-24'.")
 
     args = parser.parse_args()

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -15,7 +15,7 @@ The workflow orchestrates these steps:
 5. Create a Jira release ticket
 6. Publish a GitHub release (draft or final)
 7. Release the current Jira version and create the next version in Jira
-8. Optionally create integration tickets (SLVS, SLVSCODE, SLE, SLI, SQC, SQS)
+8. Optionally create integration tickets (SLVS, SLVSCODE, SLCORE, SLE, SLI, CLI, SQC, SQS)
 9. Optionally open analyzer update PRs in SQS and SQC
 10. Optionally post per-job and final workflow summaries when `verbose` is enabled
 
@@ -60,6 +60,7 @@ This workflow composes several actions from this repository:
 | `new-version`                | Next version to create in Jira                                                                                  | Yes      | -            |
 | `create-slvs-ticket`         | Create SLVS integration ticket                                                                                  | No       | `false`      |
 | `create-slvscode-ticket`     | Create SLVSCODE integration ticket                                                                              | No       | `false`      |
+| `create-slcore-ticket`       | Create SLCORE integration ticket                                                                                | No       | `false`      |
 | `create-sle-ticket`          | Create SLE integration ticket                                                                                   | No       | `false`      |
 | `create-sli-ticket`          | Create SLI integration ticket                                                                                   | No       | `false`      |
 | `create-cli-ticket`          | Create CLI integration ticket                                                                                   | No       | `false`      |
@@ -322,18 +323,19 @@ You need to create two workflow files:
 
 See the [Usage](#usage) section for examples, or use the [automated-release-setup skill](../skills/automated-release-setup/) for guided setup.
 
-### SonarLint Integration
+### SonarQube for IDE Integration
 
-When your analyzer is used by SonarLint, you can enable integration ticket creation for IDE teams:
+When your analyzer is used by SonarQube for IDE, you can enable integration ticket creation for its core and supported IDEs:
 
 | Input | Jira Project | Description |
 |-------|--------------|-------------|
-| `create-slvs-ticket` | SLVS | SonarLint for Visual Studio |
-| `create-slvscode-ticket` | SLVSCODE | SonarLint for VS Code |
-| `create-sle-ticket` | SLE | SonarLint for Eclipse |
-| `create-sli-ticket` | SLI | SonarLint for IntelliJ |
+| `create-slvs-ticket` | SLVS | SonarQube for Visual Studio |
+| `create-slvscode-ticket` | SLVSCODE | SonarQube for VS Code |
+| `create-slcore-ticket` | SLCORE | SonarLint Core |
+| `create-sle-ticket` | SLE | SonarQube for Eclipse |
+| `create-sli-ticket` | SLI | SonarQube for IntelliJ |
 
-Use `sq-ide-short-description` to describe changes relevant for IDE integrations.
+Use `sq-ide-short-description` to describe changes relevant for SonarQube for IDE integrations.
 
 ### CLI Integration
 
@@ -374,9 +376,9 @@ Artifacts from Repox can be attached to the GitHub release draft using the `rele
 - Update integration ticket statuses in Jira
 - Set fix versions on the SONAR ticket
 
-**If SonarLint integration is enabled:**
-- Monitor the SLVS, SLVSCode, SLE, and/or SLI tickets created in Jira
-- Coordinate with IDE teams for integration timelines
+**If SonarQube for IDE integration is enabled:**
+- Monitor the SLCORE, SLVS, SLVSCode, SLE, and/or SLI tickets created in Jira
+- Coordinate with the relevant SonarQube for IDE teams for integration timelines
 
 ### Fully-automated trigger + monitor
 


### PR DESCRIPTION
We recently started managing analyzers directly from SLCORE, the common backend to all IDE extensions. When a new analyzer version is released, we want a ticket to be created. This PR introduces a new parameter in the automated release action to allow analyzer squads to request a ticket to be created