### PR TITLE
GHA-401 Grant OIDC permission to Slack tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -50,6 +50,9 @@ jobs:
 
   test-notify-slack:
     uses: ./.github/workflows/test-notify-slack.yml
+    permissions:
+      contents: read
+      id-token: write
 
   test-lock-branch:
     uses: ./.github/workflows/test-lock-branch.yml


### PR DESCRIPTION
----
## Summary by Gitar

- **CI Workflows:**
    - Added OIDC `id-token` and `contents` permissions to `test-notify-slack` job in `.github/workflows/test-all.yml`.

<sub>This will update automatically on new commits.</sub>