### PR TITLE
GHA-402 Get rid of rule-props-changed in release github actions

### DIFF
--- a/.claude/skills/automated-release-setup/SKILL.md
+++ b/.claude/skills/automated-release-setup/SKILL.md
@@ -107,11 +107,6 @@ on:
         description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
         required: false
         type: string
-      rule-props-changed:
-        description: >
-          "@RuleProperty" changed? See SC-4654
-        type: boolean
-        default: false
       verbose:
         description: "Enable verbose logging"
         type: boolean
@@ -135,7 +130,6 @@ jobs:
       project-name: "${PROJECT_NAME}"
       plugin-name: "${PLUGIN_NAME}"
       jira-project-key: "${JIRA_PROJECT_KEY}"
-      rule-props-changed: ${{ github.event.inputs.rule-props-changed }}
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
       sqc-integration: ${{ github.event.inputs.sqc-integration == 'true' }}
@@ -178,11 +172,6 @@ on:
         description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
         required: false
         type: string
-      rule-props-changed:
-        description: >
-          "@RuleProperty" changed? See SC-4654
-        type: boolean
-        default: false
       verbose:
         description: "Enable verbose logging"
         type: boolean
@@ -206,7 +195,6 @@ jobs:
       project-name: "${PROJECT_NAME}"
       plugin-name: "${PLUGIN_NAME}"
       jira-project-key: "${JIRA_PROJECT_KEY}"
-      rule-props-changed: ${{ github.event.inputs.rule-props-changed }}
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
       sqc-integration: ${{ github.event.inputs.sqc-integration == 'true' }}
@@ -273,11 +261,6 @@ on:
         description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
         required: false
         type: string
-      rule-props-changed:
-        description: >
-          "@RuleProperty" changed? See SC-4654
-        type: boolean
-        default: false
       verbose:
         description: "Enable verbose logging"
         type: boolean
@@ -301,7 +284,6 @@ jobs:
       project-name: "${PROJECT_NAME}"
       plugin-name: "${PLUGIN_NAME}"
       jira-project-key: "${JIRA_PROJECT_KEY}"
-      rule-props-changed: ${{ github.event.inputs.rule-props-changed }}
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
       sqc-integration: ${{ github.event.inputs.sqc-integration == 'true' }}
@@ -360,11 +342,6 @@ on:
         description: "New version to release (without -SNAPSHOT; if left empty, the current minor version will be auto-incremented)"
         required: false
         type: string
-      rule-props-changed:
-        description: >
-          "@RuleProperty" changed? See SC-4654
-        type: boolean
-        default: false
       verbose:
         description: "Enable verbose logging"
         type: boolean
@@ -388,7 +365,6 @@ jobs:
       project-name: "${PROJECT_NAME}"
       plugin-name: "${PLUGIN_NAME}"
       jira-project-key: "${JIRA_PROJECT_KEY}"
-      rule-props-changed: ${{ github.event.inputs.rule-props-changed }}
       short-description: ${{ github.event.inputs.short-description }}
       new-version: ${{ github.event.inputs.new-version }}
       create-cli-ticket: ${{ github.event.inputs.cli-integration == 'true' }}

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -495,9 +495,12 @@ jobs:
 
       # Replaces the old hand-answered `rule-props-changed` input: diffs the previous release
       # tag against the release commit and looks for changed rule property declarations.
+      # continue-on-error, because a detection that cannot run must not stop a release: the
+      # step then produces no output, and the expressions below read that as "Yes".
       - name: Detect Rule Property Changes
         id: detect-rule-props
-        uses: SonarSource/release-github-actions/detect-rule-props-changed@master
+        continue-on-error: true
+        uses: SonarSource/release-github-actions/detect-rule-props-changed@ms/detect-rule-props-changed
         with:
           branch: ${{ inputs.branch }}
 
@@ -524,6 +527,7 @@ jobs:
           RULE_PROPS_BASE_REF: ${{ steps.detect-rule-props.outputs.base-ref }}
           RULE_PROPS_MATCH_COUNT: ${{ steps.detect-rule-props.outputs.match-count }}
           RULE_PROPS_MATCHED_FILES: ${{ steps.detect-rule-props.outputs.matched-files }}
+          RULE_PROPS_STATUS: ${{ steps.detect-rule-props.outputs.detection-status || 'assumed-changed' }}
         run: |
           echo "## 🆗 Prepare Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -536,18 +540,22 @@ jobs:
             echo "- Generated release notes from Jira." >> $GITHUB_STEP_SUMMARY
             echo "  - See Jira release: ${{ steps.get-jira-release-notes.outputs.jira-release-url }}" >> $GITHUB_STEP_SUMMARY
           fi
-          if [ -n "$RULE_PROPS_BASE_REF" ]; then
+          if [ "$RULE_PROPS_STATUS" = "detected" ]; then
             echo "- Scanned \`$RULE_PROPS_BASE_REF\`..\`$BRANCH\` for rule property changes." >> $GITHUB_STEP_SUMMARY
           else
-            echo "- No release tag found to compare against, so rule property changes could not be detected." >> $GITHUB_STEP_SUMMARY
+            echo "- ⚠️ Could not compare against a previous release, see detect-rule-props step for details." >> $GITHUB_STEP_SUMMARY
           fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           echo "- Release version: \`${{ needs.check-releasability.outputs.release-version || steps.get-release-version.outputs.release-version }}\`." >> $GITHUB_STEP_SUMMARY
           echo "- Jira version name: \`${{ steps.get-jira-version.outputs.jira-version-name }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\`." >> $GITHUB_STEP_SUMMARY
-          if [ "$RULE_PROPS_CHANGED" = "true" ]; then
-            echo "  - $RULE_PROPS_MATCH_COUNT change(s) in: $(echo "$RULE_PROPS_MATCHED_FILES" | tr ',' ' ')" >> $GITHUB_STEP_SUMMARY
+          if [ "$RULE_PROPS_STATUS" != "detected" ]; then
+            echo "- Rule properties changed: \`true\` — **assumed**, not detected. Check the diff by hand." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\`." >> $GITHUB_STEP_SUMMARY
+            if [ "$RULE_PROPS_CHANGED" = "true" ]; then
+              echo "  - $RULE_PROPS_MATCH_COUNT change(s) in: $(echo "$RULE_PROPS_MATCHED_FILES" | tr ',' ' ')" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
   # This step creates a Jira release ticket using the prepared release information.
@@ -571,7 +579,7 @@ jobs:
         with:
           project-name: ${{ inputs.project-name }}
           short-description: ${{ inputs.short-description }}
-          rule-props-changed: ${{ needs.prepare-release.outputs.rule-props-changed == 'true' && 'Yes' || 'No' }}
+          rule-props-changed: ${{ needs.prepare-release.outputs.rule-props-changed == 'false' && 'No' || 'Yes' }}
           jira-release-url: ${{ needs.prepare-release.outputs.jira-release-issue-filter-url }}
           start-progress: true
           version: ${{ needs.prepare-release.outputs.release-version }}
@@ -581,7 +589,7 @@ jobs:
         shell: bash
         env:
           PROJECT_NAME: ${{ inputs.project-name }}
-          RULE_PROPS_CHANGED: ${{ needs.prepare-release.outputs.rule-props-changed == 'true' && 'Yes' || 'No' }}
+          RULE_PROPS_CHANGED: ${{ needs.prepare-release.outputs.rule-props-changed == 'false' && 'No' || 'Yes' }}
           RULE_PROPS_BASE_REF: ${{ needs.prepare-release.outputs.rule-props-base-ref }}
           RULE_PROPS_MATCHED_FILES: ${{ needs.prepare-release.outputs.rule-props-matched-files }}
         run: |
@@ -589,7 +597,11 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### What happened" >> $GITHUB_STEP_SUMMARY
           echo "- Created a Jira release ticket for project \`$PROJECT_NAME\` using version \`${{ needs.prepare-release.outputs.release-version }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\` (detected against \`${RULE_PROPS_BASE_REF:-no baseline tag}\`)." >> $GITHUB_STEP_SUMMARY
+          if [ -n "$RULE_PROPS_BASE_REF" ]; then
+            echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\` (detected against \`$RULE_PROPS_BASE_REF\`)." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\` — ⚠️ **assumed**. Check the diff by hand." >> $GITHUB_STEP_SUMMARY
+          fi
           if [ -n "$RULE_PROPS_MATCHED_FILES" ]; then
             echo "  - Changed in: $(echo "$RULE_PROPS_MATCHED_FILES" | tr ',' ' ')" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -72,8 +72,11 @@ on:
         required: true
         type: string
       rule-props-changed:
-        description: "Did any rule properties change in this release"
-        required: true
+        description: >
+          Deprecated, no-op. Whether rule properties changed is now detected automatically by
+          diffing the previous release tag against the release commit. Any value passed here is
+          ignored; the input is kept only so existing callers keep working and can drop it.
+        required: false
         type: string
       branch:
         description: "Branch from which to do the release"
@@ -479,11 +482,22 @@ jobs:
       jira-release-notes: ${{ inputs.release-notes != '' && inputs.release-notes || steps.get-jira-release-notes.outputs.jira-release-notes }}
       jira-release-url: ${{ steps.get-jira-release-notes.outputs.jira-release-url }}
       jira-release-issue-filter-url: ${{ steps.get-jira-release-notes.outputs.jira-release-issue-filter-url }}
+      rule-props-changed: ${{ steps.detect-rule-props.outputs.rule-props-changed }}
+      rule-props-base-ref: ${{ steps.detect-rule-props.outputs.base-ref }}
+      rule-props-matched-files: ${{ steps.detect-rule-props.outputs.matched-files }}
     steps:
       - name: Get Release Version
         id: get-release-version
         if: ${{ needs.check-releasability.result == 'skipped' }}
         uses: SonarSource/release-github-actions/get-release-version@master
+        with:
+          branch: ${{ inputs.branch }}
+
+      # Replaces the old hand-answered `rule-props-changed` input: diffs the previous release
+      # tag against the release commit and looks for changed rule property declarations.
+      - name: Detect Rule Property Changes
+        id: detect-rule-props
+        uses: SonarSource/release-github-actions/detect-rule-props-changed@master
         with:
           branch: ${{ inputs.branch }}
 
@@ -506,6 +520,10 @@ jobs:
           JIRA_PROJECT_KEY: ${{ inputs.jira-project-key }}
           USE_JIRA_SANDBOX: ${{ inputs.use-jira-sandbox == true && 'true' || 'false' }}
           RELEASE_NOTES: ${{ inputs.release-notes }}
+          RULE_PROPS_CHANGED: ${{ steps.detect-rule-props.outputs.rule-props-changed }}
+          RULE_PROPS_BASE_REF: ${{ steps.detect-rule-props.outputs.base-ref }}
+          RULE_PROPS_MATCH_COUNT: ${{ steps.detect-rule-props.outputs.match-count }}
+          RULE_PROPS_MATCHED_FILES: ${{ steps.detect-rule-props.outputs.matched-files }}
         run: |
           echo "## 🆗 Prepare Release" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -518,10 +536,19 @@ jobs:
             echo "- Generated release notes from Jira." >> $GITHUB_STEP_SUMMARY
             echo "  - See Jira release: ${{ steps.get-jira-release-notes.outputs.jira-release-url }}" >> $GITHUB_STEP_SUMMARY
           fi
+          if [ -n "$RULE_PROPS_BASE_REF" ]; then
+            echo "- Scanned \`$RULE_PROPS_BASE_REF\`..\`$BRANCH\` for rule property changes." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- No release tag found to compare against, so rule property changes could not be detected." >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           echo "- Release version: \`${{ needs.check-releasability.outputs.release-version || steps.get-release-version.outputs.release-version }}\`." >> $GITHUB_STEP_SUMMARY
           echo "- Jira version name: \`${{ steps.get-jira-version.outputs.jira-version-name }}\`." >> $GITHUB_STEP_SUMMARY
+          echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\`." >> $GITHUB_STEP_SUMMARY
+          if [ "$RULE_PROPS_CHANGED" = "true" ]; then
+            echo "  - $RULE_PROPS_MATCH_COUNT change(s) in: $(echo "$RULE_PROPS_MATCHED_FILES" | tr ',' ' ')" >> $GITHUB_STEP_SUMMARY
+          fi
 
   # This step creates a Jira release ticket using the prepared release information.
   # It outputs the release ticket key and URL for further use.
@@ -544,7 +571,7 @@ jobs:
         with:
           project-name: ${{ inputs.project-name }}
           short-description: ${{ inputs.short-description }}
-          rule-props-changed: ${{ inputs.rule-props-changed == 'true' && 'Yes' || 'No' }}
+          rule-props-changed: ${{ needs.prepare-release.outputs.rule-props-changed == 'true' && 'Yes' || 'No' }}
           jira-release-url: ${{ needs.prepare-release.outputs.jira-release-issue-filter-url }}
           start-progress: true
           version: ${{ needs.prepare-release.outputs.release-version }}
@@ -554,13 +581,18 @@ jobs:
         shell: bash
         env:
           PROJECT_NAME: ${{ inputs.project-name }}
-          RULE_PROPS_CHANGED: ${{ inputs.rule-props-changed }}
+          RULE_PROPS_CHANGED: ${{ needs.prepare-release.outputs.rule-props-changed == 'true' && 'Yes' || 'No' }}
+          RULE_PROPS_BASE_REF: ${{ needs.prepare-release.outputs.rule-props-base-ref }}
+          RULE_PROPS_MATCHED_FILES: ${{ needs.prepare-release.outputs.rule-props-matched-files }}
         run: |
           echo "## 🧾 Create Release Ticket" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### What happened" >> $GITHUB_STEP_SUMMARY
           echo "- Created a Jira release ticket for project \`$PROJECT_NAME\` using version \`${{ needs.prepare-release.outputs.release-version }}\`." >> $GITHUB_STEP_SUMMARY
-          echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\`." >> $GITHUB_STEP_SUMMARY
+          echo "- Rule properties changed: \`$RULE_PROPS_CHANGED\` (detected against \`${RULE_PROPS_BASE_REF:-no baseline tag}\`)." >> $GITHUB_STEP_SUMMARY
+          if [ -n "$RULE_PROPS_MATCHED_FILES" ]; then
+            echo "  - Changed in: $(echo "$RULE_PROPS_MATCHED_FILES" | tr ',' ' ')" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           echo "- Ticket key: \`${{ steps.create-ticket.outputs.release-ticket-key }}\`." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -48,6 +48,9 @@ jobs:
   test-update-rule-metadata:
     uses: ./.github/workflows/test-update-rule-metadata.yml
 
+  test-detect-rule-props-changed:
+    uses: ./.github/workflows/test-detect-rule-props-changed.yml
+
   test-notify-slack:
     uses: ./.github/workflows/test-notify-slack.yml
     permissions:

--- a/.github/workflows/test-detect-rule-props-changed.yml
+++ b/.github/workflows/test-detect-rule-props-changed.yml
@@ -56,18 +56,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      # The action checks out $GITHUB_WORKSPACE itself, so the fixture commits are made on this
-      # repository's own checkout: a baseline tag, then a change on top of it.
-      - name: Create a rule property change on top of a tagged baseline
-        env:
-          FIXTURE_TAG: rule-props-fixture-${{ github.run_id }}
+      # The fixture is built under $RUNNER_TEMP, not in $GITHUB_WORKSPACE, and the action is
+      # pointed at it with `repository-path`. Committing fixtures into the workspace instead
+      # cannot work: the action's own `actions/checkout` replaces the workspace wholesale, so
+      # the fixture -- and, for a local `uses: ./`, the action's own source -- would be gone
+      # before the detector ran.
+      - name: Create the fixture repository with a tagged baseline
         run: |
           set -euo pipefail
-          git config user.email "test@example.com"
-          git config user.name "Test"
+          FIXTURE="$RUNNER_TEMP/rule-props-fixture"
+          echo "FIXTURE=$FIXTURE" >> "$GITHUB_ENV"
 
-          mkdir -p fixture/src/main/java
-          cat > fixture/src/main/java/NamingCheck.java <<'JAVA'
+          mkdir -p "$FIXTURE/src/main/java"
+          git -C "$FIXTURE" init -q -b master
+          git -C "$FIXTURE" config user.email "test@example.com"
+          git -C "$FIXTURE" config user.name "Test"
+          git -C "$FIXTURE" config commit.gpgsign false
+
+          cat > "$FIXTURE/src/main/java/NamingCheck.java" <<'JAVA'
           import org.sonar.check.RuleProperty;
 
           public class NamingCheck {
@@ -75,76 +81,123 @@ jobs:
             public String format = "^[a-z]+$";
           }
           JAVA
-          git add -A && git commit -q -m "fixture baseline"
-          git tag "$FIXTURE_TAG"
+          git -C "$FIXTURE" add -A
+          git -C "$FIXTURE" commit -q -m "baseline"
+          git -C "$FIXTURE" tag 1.0.0.100
 
-          # Rename the property key -- a genuine rule property change.
-          FILE=fixture/src/main/java/NamingCheck.java
-          sed 's/key = "format"/key = "namingFormat"/' "$FILE" > "$FILE.tmp"
-          mv "$FILE.tmp" "$FILE"
-          git add -A && git commit -q -m "fixture: rename rule property key"
+      - name: Rename a rule property key
+        run: |
+          set -euo pipefail
+          sed -i 's/key = "format"/key = "namingFormat"/' \
+            "$FIXTURE/src/main/java/NamingCheck.java"
+          git -C "$FIXTURE" commit -qam "rename the rule property key"
 
+      # No base-ref, so the action has to resolve the baseline itself via `git describe`.
       - name: Detect (expects true)
         id: changed
         uses: ./detect-rule-props-changed
         with:
-          base-ref: rule-props-fixture-${{ github.run_id }}
+          repository-path: ${{ env.FIXTURE }}
 
       - name: Verify a change was detected
         env:
           RESULT: ${{ steps.changed.outputs.rule-props-changed }}
+          STATUS: ${{ steps.changed.outputs.detection-status }}
           MATCHED: ${{ steps.changed.outputs.matched-files }}
           BASE_REF: ${{ steps.changed.outputs.base-ref }}
-          EXPECTED_BASE: rule-props-fixture-${{ github.run_id }}
         run: |
-          if [[ "$RESULT" != "true" ]]; then
-            echo "❌ Expected rule-props-changed=true, got '$RESULT'"
+          if [[ "$RESULT" != "true" || "$STATUS" != "detected" ]]; then
+            echo "❌ Expected true/detected, got '$RESULT'/'$STATUS'"
             exit 1
           fi
           if [[ "$MATCHED" != *"NamingCheck.java"* ]]; then
             echo "❌ Expected NamingCheck.java in matched-files, got '$MATCHED'"
             exit 1
           fi
-          if [[ "$BASE_REF" != "$EXPECTED_BASE" ]]; then
-            echo "❌ Expected base-ref '$EXPECTED_BASE', got '$BASE_REF'"
+          if [[ "$BASE_REF" != "1.0.0.100" ]]; then
+            echo "❌ Expected the baseline to resolve to 1.0.0.100, got '$BASE_REF'"
             exit 1
           fi
           echo "✅ detected: $MATCHED"
 
-      # An unrelated import added to the same file: the classic false positive a plain
-      # `grep RuleProperty` over the diff would report.
+      # The action must not have replaced the workspace with its own checkout.
+      - name: Verify the caller's workspace was left alone
+        run: |
+          if [[ ! -f detect-rule-props-changed/action.yml ]]; then
+            echo "❌ The action clobbered the workspace it was told not to touch"
+            exit 1
+          fi
+          echo "✅ workspace untouched"
+
+      # An unrelated import added to a check class: the classic false positive a plain
+      # `grep RuleProperty` over the diff would report, because the import shows up as context.
       - name: Add an unrelated import on a fresh baseline
-        env:
-          FIXTURE_TAG: rule-props-fixture-clean-${{ github.run_id }}
         run: |
           set -euo pipefail
-          git tag "$FIXTURE_TAG"
-          FILE=fixture/src/main/java/NamingCheck.java
+          git -C "$FIXTURE" tag 1.0.0.101
+          FILE="$FIXTURE/src/main/java/NamingCheck.java"
           { echo 'import java.util.List;'; cat "$FILE"; } > "$FILE.tmp"
           mv "$FILE.tmp" "$FILE"
-          git add -A && git commit -q -m "fixture: unrelated import"
+          git -C "$FIXTURE" commit -qam "unrelated import"
 
       - name: Detect (expects false)
         id: unchanged
         uses: ./detect-rule-props-changed
         with:
-          base-ref: rule-props-fixture-clean-${{ github.run_id }}
+          repository-path: ${{ env.FIXTURE }}
 
       - name: Verify the import was not mistaken for a property change
         env:
           RESULT: ${{ steps.unchanged.outputs.rule-props-changed }}
-          MATCHED: ${{ steps.unchanged.outputs.matched-files }}
           STATUS: ${{ steps.unchanged.outputs.detection-status }}
+          MATCHED: ${{ steps.unchanged.outputs.matched-files }}
+          BASE_REF: ${{ steps.unchanged.outputs.base-ref }}
         run: |
           if [[ "$RESULT" != "false" ]]; then
-            echo "❌ Expected rule-props-changed=false for an import-only change, got '$RESULT' ($MATCHED)"
+            echo "❌ Expected false for an import-only change, got '$RESULT' ($MATCHED)"
             exit 1
           fi
           if [[ "$STATUS" != "detected" ]]; then
             echo "❌ Expected detection-status=detected, got '$STATUS'"
             exit 1
           fi
+          if [[ "$BASE_REF" != "1.0.0.101" ]]; then
+            echo "❌ Expected the baseline to resolve to 1.0.0.101, got '$BASE_REF'"
+            exit 1
+          fi
           echo "✅ import-only change correctly reported as no rule property change"
+
+      # Deleting the check removes its properties too. git names the target of a deletion
+      # `/dev/null`, so a parser keyed only off the `+++` line drops the hunk that holds the
+      # removed declarations and reports a real removal as no change.
+      - name: Delete the whole check class
+        run: |
+          set -euo pipefail
+          git -C "$FIXTURE" tag 1.0.0.102
+          git -C "$FIXTURE" rm -q src/main/java/NamingCheck.java
+          git -C "$FIXTURE" commit -qm "drop the check entirely"
+
+      - name: Detect (expects true for the deletion)
+        id: deleted
+        uses: ./detect-rule-props-changed
+        with:
+          repository-path: ${{ env.FIXTURE }}
+
+      - name: Verify the deletion was detected
+        env:
+          RESULT: ${{ steps.deleted.outputs.rule-props-changed }}
+          STATUS: ${{ steps.deleted.outputs.detection-status }}
+          MATCHED: ${{ steps.deleted.outputs.matched-files }}
+        run: |
+          if [[ "$RESULT" != "true" || "$STATUS" != "detected" ]]; then
+            echo "❌ Expected a deleted check class to be detected, got '$RESULT'/'$STATUS'"
+            exit 1
+          fi
+          if [[ "$MATCHED" != *"NamingCheck.java"* ]]; then
+            echo "❌ Expected the deleted file in matched-files, got '$MATCHED'"
+            exit 1
+          fi
+          echo "✅ deleted check class reported as a rule property change"
 
       # A comparison that cannot be made must answer "changed", never "unchanged": an
       # undetected rule property change reaching SQC is far more expensive than a spurious Yes.
@@ -152,6 +205,7 @@ jobs:
         id: undetermined
         uses: ./detect-rule-props-changed
         with:
+          repository-path: ${{ env.FIXTURE }}
           base-ref: no-such-tag-${{ github.run_id }}
 
       - name: Verify an impossible comparison falls back to "changed"

--- a/.github/workflows/test-detect-rule-props-changed.yml
+++ b/.github/workflows/test-detect-rule-props-changed.yml
@@ -1,0 +1,142 @@
+name: Test detect-rule-props-changed
+
+on:
+  workflow_call:
+  pull_request:
+    paths:
+      - 'detect-rule-props-changed/**'
+      - 'shared/**'
+      - '.github/workflows/test-detect-rule-props-changed.yml'
+  push:
+    branches:
+      - master
+      - v*
+    paths:
+      - 'detect-rule-props-changed/**'
+      - 'shared/**'
+      - '.github/workflows/test-detect-rule-props-changed.yml'
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    name: Run Unit Tests
+    runs-on: github-ubuntu-latest-s
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install pytest pytest-cov
+
+      - name: Run unit tests
+        run: |
+          cd detect-rule-props-changed
+          python -m pytest test_detect_rule_props_changed.py -v \
+            --cov=detect_rule_props_changed \
+            --cov-report=term-missing \
+            --cov-report=xml:coverage.xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: coverage-report-detect-rule-props-changed
+          path: detect-rule-props-changed/coverage.xml
+
+  integration-test:
+    name: Integration Test (synthetic repository)
+    runs-on: github-ubuntu-latest-s
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      # The action checks out $GITHUB_WORKSPACE itself, so the fixture commits are made on this
+      # repository's own checkout: a baseline tag, then a change on top of it.
+      - name: Create a rule property change on top of a tagged baseline
+        env:
+          FIXTURE_TAG: rule-props-fixture-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          git config user.email "test@example.com"
+          git config user.name "Test"
+
+          mkdir -p fixture/src/main/java
+          cat > fixture/src/main/java/NamingCheck.java <<'JAVA'
+          import org.sonar.check.RuleProperty;
+
+          public class NamingCheck {
+            @RuleProperty(key = "format", defaultValue = "^[a-z]+$")
+            public String format = "^[a-z]+$";
+          }
+          JAVA
+          git add -A && git commit -q -m "fixture baseline"
+          git tag "$FIXTURE_TAG"
+
+          # Rename the property key -- a genuine rule property change.
+          FILE=fixture/src/main/java/NamingCheck.java
+          sed 's/key = "format"/key = "namingFormat"/' "$FILE" > "$FILE.tmp"
+          mv "$FILE.tmp" "$FILE"
+          git add -A && git commit -q -m "fixture: rename rule property key"
+
+      - name: Detect (expects true)
+        id: changed
+        uses: ./detect-rule-props-changed
+        with:
+          base-ref: rule-props-fixture-${{ github.run_id }}
+
+      - name: Verify a change was detected
+        env:
+          RESULT: ${{ steps.changed.outputs.rule-props-changed }}
+          MATCHED: ${{ steps.changed.outputs.matched-files }}
+          BASE_REF: ${{ steps.changed.outputs.base-ref }}
+          EXPECTED_BASE: rule-props-fixture-${{ github.run_id }}
+        run: |
+          if [[ "$RESULT" != "true" ]]; then
+            echo "❌ Expected rule-props-changed=true, got '$RESULT'"
+            exit 1
+          fi
+          if [[ "$MATCHED" != *"NamingCheck.java"* ]]; then
+            echo "❌ Expected NamingCheck.java in matched-files, got '$MATCHED'"
+            exit 1
+          fi
+          if [[ "$BASE_REF" != "$EXPECTED_BASE" ]]; then
+            echo "❌ Expected base-ref '$EXPECTED_BASE', got '$BASE_REF'"
+            exit 1
+          fi
+          echo "✅ detected: $MATCHED"
+
+      # An unrelated import added to the same file: the classic false positive a plain
+      # `grep RuleProperty` over the diff would report.
+      - name: Add an unrelated import on a fresh baseline
+        env:
+          FIXTURE_TAG: rule-props-fixture-clean-${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          git tag "$FIXTURE_TAG"
+          FILE=fixture/src/main/java/NamingCheck.java
+          { echo 'import java.util.List;'; cat "$FILE"; } > "$FILE.tmp"
+          mv "$FILE.tmp" "$FILE"
+          git add -A && git commit -q -m "fixture: unrelated import"
+
+      - name: Detect (expects false)
+        id: unchanged
+        uses: ./detect-rule-props-changed
+        with:
+          base-ref: rule-props-fixture-clean-${{ github.run_id }}
+
+      - name: Verify the import was not mistaken for a property change
+        env:
+          RESULT: ${{ steps.unchanged.outputs.rule-props-changed }}
+          MATCHED: ${{ steps.unchanged.outputs.matched-files }}
+        run: |
+          if [[ "$RESULT" != "false" ]]; then
+            echo "❌ Expected rule-props-changed=false for an import-only change, got '$RESULT' ($MATCHED)"
+            exit 1
+          fi
+          echo "✅ import-only change correctly reported as no rule property change"

--- a/.github/workflows/test-detect-rule-props-changed.yml
+++ b/.github/workflows/test-detect-rule-props-changed.yml
@@ -134,9 +134,37 @@ jobs:
         env:
           RESULT: ${{ steps.unchanged.outputs.rule-props-changed }}
           MATCHED: ${{ steps.unchanged.outputs.matched-files }}
+          STATUS: ${{ steps.unchanged.outputs.detection-status }}
         run: |
           if [[ "$RESULT" != "false" ]]; then
             echo "❌ Expected rule-props-changed=false for an import-only change, got '$RESULT' ($MATCHED)"
             exit 1
           fi
+          if [[ "$STATUS" != "detected" ]]; then
+            echo "❌ Expected detection-status=detected, got '$STATUS'"
+            exit 1
+          fi
           echo "✅ import-only change correctly reported as no rule property change"
+
+      # A comparison that cannot be made must answer "changed", never "unchanged": an
+      # undetected rule property change reaching SQC is far more expensive than a spurious Yes.
+      - name: Detect against a baseline that does not exist (expects the safe fallback)
+        id: undetermined
+        uses: ./detect-rule-props-changed
+        with:
+          base-ref: no-such-tag-${{ github.run_id }}
+
+      - name: Verify an impossible comparison falls back to "changed"
+        env:
+          RESULT: ${{ steps.undetermined.outputs.rule-props-changed }}
+          STATUS: ${{ steps.undetermined.outputs.detection-status }}
+        run: |
+          if [[ "$RESULT" != "true" ]]; then
+            echo "❌ Expected the fallback to report rule-props-changed=true, got '$RESULT'"
+            exit 1
+          fi
+          if [[ "$STATUS" != "assumed-changed" ]]; then
+            echo "❌ Expected detection-status=assumed-changed, got '$STATUS'"
+            exit 1
+          fi
+          echo "✅ undeterminable comparison assumed changed"

--- a/.okf/actions/detect-rule-props-changed.md
+++ b/.okf/actions/detect-rule-props-changed.md
@@ -19,6 +19,25 @@ and almost always hardcoded to `false`. That input is now a deprecated no-op —
 Called from the `prepare-release` job, which exposes the result as the `rule-props-changed`,
 `rule-props-base-ref` and `rule-props-matched-files` job outputs.
 
+# Fail-safe
+
+The answer is asymmetric: an undetected rule property change reaching SQC is a production
+surprise, an unnecessary "Yes" is one manual check. So **every path that cannot produce an answer
+resolves to `true`** — no reachable tag, a shallow checkout, an unresolvable ref, malformed
+`extra-patterns`, a failing `git diff`, or an unforeseen exception.
+
+The fallback is enforced at three levels, because each one covers a hole the level below cannot:
+
+1. **Script** — never exits non-zero. A non-zero exit writes no outputs at all, and an absent
+   output reads downstream as "unchanged" — precisely the failure the fallback exists to prevent.
+   Output values are collapsed to a single line: `$GITHUB_OUTPUT` is one `key=value` per line, so
+   a newline inside a git error message could otherwise inject `rule-props-changed=false`.
+2. **`action.yml`** — wraps the interpreter call, so a detector that cannot start (broken
+   interpreter, unreadable script) still writes the safe outputs.
+3. **[automated-release](/workflows/automated-release.md)** — the detect step is
+   `continue-on-error`, and the ticket expression is `== 'false' && 'No' || 'Yes'`, so a failed
+   or skipped step yields an empty output that maps to `Yes` rather than `No`.
+
 # Detection
 
 Baseline is the nearest tag **reachable from** the release commit
@@ -61,17 +80,19 @@ which the changed-line matcher reports cleanly.
 
 | Output | Description |
 |---|---|
-| `rule-props-changed` | `"true"` / `"false"` |
-| `base-ref` | Baseline compared against; empty when no tag was reachable |
+| `rule-props-changed` | `"true"` / `"false"`; `"true"` also when no comparison was possible |
+| `base-ref` | Baseline compared against; empty when no comparison was made |
 | `match-count` | Number of changed lines that altered a declaration |
 | `matched-files` | Comma-separated files, capped at 20 |
+| `detection-status` | `"detected"` / `"assumed-changed"` |
 
 # Notes
 
-- No reachable tag (first release) → `::warning::` and `false`; there is no baseline.
 - A default held in a distant constant (`defaultValue = "" + DEFAULT_THRESHOLD`) is only detected
   when the declaration block itself changes.
 - Test sources are excluded by default: changing a test fixture is not a released behaviour change.
+- `rule-props-changed=true` with `match-count=0` is the fallback, not a contradiction — read
+  `detection-status` to tell the two apart.
 
 # Citations
 

--- a/.okf/actions/detect-rule-props-changed.md
+++ b/.okf/actions/detect-rule-props-changed.md
@@ -77,6 +77,7 @@ which the changed-line matcher reports cleanly.
 | `head-ref` | Commit being released | No | `HEAD` |
 | `extra-patterns` | Extra `<pathspec>::<regex>` rules, one per line | No | - |
 | `include-test-sources` | Scan test sources too | No | `false` |
+| `repository-path` | Inspect this checkout and skip the action's own | No | - |
 
 | Output | Description |
 |---|---|
@@ -93,6 +94,10 @@ which the changed-line matcher reports cleanly.
 - Test sources are excluded by default: changing a test fixture is not a released behaviour change.
 - `rule-props-changed=true` with `match-count=0` is the fallback, not a contradiction — read
   `detection-status` to tell the two apart.
+- The default checkout **replaces `$GITHUB_WORKSPACE`**, so steps after this one in the same job
+  see the checked-out branch rather than whatever was there. `repository-path` suppresses it;
+  the integration test relies on that, since a local `uses: ./` action whose own source lives in
+  the workspace deletes itself the moment the internal checkout runs.
 
 # Citations
 

--- a/.okf/actions/detect-rule-props-changed.md
+++ b/.okf/actions/detect-rule-props-changed.md
@@ -1,0 +1,78 @@
+---
+type: GitHub Action
+title: Detect Rule Property Changes
+description: Diffs the previous release tag against the release commit to decide whether any rule property declaration changed.
+resource: https://github.com/SonarSource/release-github-actions/tree/master/detect-rule-props-changed
+tags: [action, release, rule-properties, jira]
+timestamp: 2026-08-10T00:00:00Z
+---
+
+# Overview
+
+Computes the *Rule Properties Changed* field (`customfield_11263`, SC-4654) that
+[create-jira-release-ticket](/actions/create-jira-release-ticket.md) writes onto the REL ticket.
+Before this action the value came from the hand-answered `rule-props-changed` input on
+[automated-release](/workflows/automated-release.md), which 42 caller repositories passed by hand
+and almost always hardcoded to `false`. That input is now a deprecated no-op — see
+[input sprawl](/risks/input-sprawl.md).
+
+Called from the `prepare-release` job, which exposes the result as the `rule-props-changed`,
+`rule-props-base-ref` and `rule-props-matched-files` job outputs.
+
+# Detection
+
+Baseline is the nearest tag **reachable from** the release commit
+(`git describe --tags --abbrev=0`). Reachability is what makes maintenance-branch releases
+correct: the newest tag in the repository is usually not an ancestor of a dot release. If that tag
+points at the release commit itself (a re-run, after the tag was created) the action steps back
+one release rather than comparing the commit with itself. The action checks out with
+`fetch-depth: 0` so tags and history are present.
+
+Analyzers do not share one convention, so the ruleset carries one entry per convention:
+
+| Pattern | Files | Analyzers |
+|---|---|---|
+| `@RuleProperty(` | `*.java`, `*.kt` | sonar-python, sonar-java, sonar-go, sonar-iac, sonar-kotlin |
+| `new RuleParameter(` | `*.java`, `*.kt` | sonar-swift, sonar-dart (central `*RulesDefinition.java`) |
+| `[RuleParameter(` | `*.cs` | sonar-dotnet-enterprise |
+| `field:` / `default:` / `displayName:` | `*/rules/*/config.ts` | SonarJS |
+
+**SonarJS is why the TypeScript entry exists**: its `@RuleProperty` Java classes are generated and
+gitignored (`sonar-plugin/javascript-checks/src/main/java/.../.gitignore` ignores `S*.java`), so
+they never appear in a diff. The tracked declaration is the `config.ts` they are generated from.
+
+Matching runs on **changed lines**, not the whole diff. A line counts when it is not an
+`import`/`using` line and either declares a rule property, or edits a declaration attribute
+(`key`, `defaultValue`, `description`, `type`, `paramKey`) inside a hunk that shows the
+declaration. Grepping the raw diff instead produces frequent false positives, because
+`import org.sonar.check.RuleProperty;` appears as *context* whenever an unrelated import is added
+to a check class — replaying a plain grep over 35 real release-tag pairs surfaced 8 such files,
+which the changed-line matcher reports cleanly.
+
+# Schema
+
+| Input | Description | Required | Default |
+|---|---|---|---|
+| `branch` | Branch being released, used as the checkout ref | No | `master` |
+| `base-ref` | Ref to compare against | No | nearest reachable tag |
+| `head-ref` | Commit being released | No | `HEAD` |
+| `extra-patterns` | Extra `<pathspec>::<regex>` rules, one per line | No | - |
+| `include-test-sources` | Scan test sources too | No | `false` |
+
+| Output | Description |
+|---|---|
+| `rule-props-changed` | `"true"` / `"false"` |
+| `base-ref` | Baseline compared against; empty when no tag was reachable |
+| `match-count` | Number of changed lines that altered a declaration |
+| `matched-files` | Comma-separated files, capped at 20 |
+
+# Notes
+
+- No reachable tag (first release) → `::warning::` and `false`; there is no baseline.
+- A default held in a distant constant (`defaultValue = "" + DEFAULT_THRESHOLD`) is only detected
+  when the declaration block itself changes.
+- Test sources are excluded by default: changing a test fixture is not a released behaviour change.
+
+# Citations
+
+[1] [detect-rule-props-changed/README.md](/../detect-rule-props-changed/README.md)

--- a/.okf/actions/index.md
+++ b/.okf/actions/index.md
@@ -6,6 +6,7 @@
 * [create-jira-release-ticket](create-jira-release-ticket.md) - creates the "Ask for release" ticket in Jira.
 * [create-jira-version](create-jira-version.md) - creates a new version in a Jira project.
 * [create-pull-request](create-pull-request.md) - shared PR-creation building block using the `gh` CLI.
+* [detect-rule-props-changed](detect-rule-props-changed.md) - detects rule property changes since the previous release tag.
 * [get-jira-release-notes](get-jira-release-notes.md) - fetches and formats Jira release notes.
 * [get-jira-version](get-jira-version.md) - converts a release version to Jira's version naming convention.
 * [get-release-version](get-release-version.md) - extracts the release version from the repox commit status.

--- a/.okf/index.md
+++ b/.okf/index.md
@@ -9,7 +9,7 @@ Jira integration, GitHub releases, cross-repository updates, and Slack notificat
 
 # Directories
 
-* [actions/](actions/) - the 22 composite GitHub Actions in this repo, one concept per action.
+* [actions/](actions/) - the 23 composite GitHub Actions in this repo, one concept per action.
 * [workflows/](workflows/) - the reusable `workflow_call` orchestrators (automated-release, ide-automated-release, abd-automated-release, release-lock) and the repo's own release workflow.
 * [shared/](shared/) - Python helpers shared across Jira-integration actions.
 * [decisions/](decisions/) - architectural rules and reviews governing this repo (Golden Architecture, security conventions, the 2026-07 architecture review).

--- a/.okf/risks/input-sprawl.md
+++ b/.okf/risks/input-sprawl.md
@@ -14,8 +14,12 @@ expressions, with valid combinations undocumented and unenforced:
 - `sqaa-integration: true` with `sqc-integration: false` → the job is silently skipped (`:946`).
 - `sqc-plugins-deployer-integration` is a **deprecated no-op** still in the schema with
   `default: true` — appears in every dispatch form and setup doc.
-- `rule-props-changed` is a required *string* `"true"`/`"false"` compared with `== 'true'`
-  (`:537`): pass a real boolean or `"True"` and it silently maps to "No."
+- ~~`rule-props-changed` is a required *string* `"true"`/`"false"` compared with `== 'true'`
+  (`:537`): pass a real boolean or `"True"` and it silently maps to "No."~~ **Addressed
+  2026-08-10**: the value is now computed by
+  [detect-rule-props-changed](/actions/detect-rule-props-changed.md) and the input is a
+  deprecated no-op. It stays declared until the 42 caller repos drop it, since GitHub errors on
+  an undeclared reusable-workflow input — a worked example of why pruning an input is not free.
 - `new-version` is documented **required** in [AUTOMATED_RELEASE.md](/../docs/AUTOMATED_RELEASE.md)
   but is `required: false` in the YAML (`:91`) — omitting it changes what Jira creates next, and
   **docs and schema disagree**.

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -83,9 +83,12 @@ Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 - **Rule properties are detected, not declared**: `prepare-release` runs
   [detect-rule-props-changed](/actions/detect-rule-props-changed.md) against the previous release
   tag and exposes `rule-props-changed`, which `create-release-ticket` maps to Yes/No on the REL
-  ticket. The `rule-props-changed` *input* is a deprecated no-op, kept only so the 42 caller repos
-  that still pass it keep working — GitHub errors on an undeclared reusable-workflow input, so it
-  can only be deleted after the callers drop it.
+  ticket. The mapping is `== 'false' && 'No' || 'Yes'`, not `== 'true' && 'Yes' || 'No'`: the step
+  is `continue-on-error`, so it can legitimately produce no output, and an empty value must land
+  on Yes. Inverting this expression would silently reintroduce the unsafe default the detector
+  was built to remove. The `rule-props-changed` *input* is a deprecated no-op, kept only so the
+  42 caller repos that still pass it keep working — GitHub errors on an undeclared
+  reusable-workflow input, so it can only be deleted after the callers drop it.
 - **Auto-merge sweep**: when `bump-version: true`, strips auto-merge from all open PRs at
   release start, to reduce the race window where a PR could merge before the version-bump PR
   opens. Best-effort — see the [release-lock gate](/workflows/release-lock.md) for the guard of

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -66,7 +66,7 @@ Actions composed: [get-release-version](/actions/get-release-version.md),
 # Schema
 
 Key inputs (selected — full list in the action README): `jira-project-key`, `project-name`,
-`plugin-name`, `pm-email`, `short-description`, `rule-props-changed`, `branch`, `new-version`,
+`plugin-name`, `pm-email`, `short-description`, `branch`, `new-version`,
 `use-jira-sandbox` (default `true`), `is-draft-release` (default `true`), `freeze-branch`
 (default `true`), `check-releasability` (default `true`), `sqs-integration` /
 `sqc-integration` (default `true`), `sqaa-integration` (runs only when `sqc-integration` is
@@ -80,6 +80,12 @@ Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 
 # Notes
 
+- **Rule properties are detected, not declared**: `prepare-release` runs
+  [detect-rule-props-changed](/actions/detect-rule-props-changed.md) against the previous release
+  tag and exposes `rule-props-changed`, which `create-release-ticket` maps to Yes/No on the REL
+  ticket. The `rule-props-changed` *input* is a deprecated no-op, kept only so the 42 caller repos
+  that still pass it keep working — GitHub errors on an undeclared reusable-workflow input, so it
+  can only be deleted after the callers drop it.
 - **Auto-merge sweep**: when `bump-version: true`, strips auto-merge from all open PRs at
   release start, to reduce the race window where a PR could merge before the version-bump PR
   opens. Best-effort — see the [release-lock gate](/workflows/release-lock.md) for the guard of

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ steps, and the freeze-coexistence guarantee.
 | [Create Pull Request](create-pull-request/README.md)                    | Creates or updates a pull request using the `gh` CLI, with vault-based token resolution |
 | [Create Jira Release Ticket](create-jira-release-ticket/README.md)      | Automates the creation of an "Ask for release" ticket in Jira |
 | [Create Jira Version](create-jira-version/README.md)                    | Creates a new version in a Jira project, with the ability to automatically determine the next version number |
+| [Detect Rule Property Changes](detect-rule-props-changed/README.md)     | Detects whether any rule property declaration changed since the previous release tag |
 | [Get Jira Release Notes](get-jira-release-notes/README.md)              | Fetches Jira release notes and generates the release notes URL for a given project and version |
 | [Get Jira Version](get-jira-version/README.md)                          | Extracts a Jira-compatible version number from a release version by formatting it appropriately for Jira |
 | [Get Release Version](get-release-version/README.md)                    | Extracts the release version from the repox status on a specified branch |

--- a/detect-rule-props-changed/README.md
+++ b/detect-rule-props-changed/README.md
@@ -1,0 +1,115 @@
+# Detect Rule Property Changes
+
+Detects whether any **rule property** (rule parameter) declaration changed between the previous
+release and the commit being released.
+
+The result feeds the *Rule Properties Changed* field (`customfield_11263`) on the Jira release
+ticket — see SC-4654. That field used to be answered by hand through the `rule-props-changed`
+workflow input; this action computes it instead.
+
+## How it works
+
+1. Resolves a baseline: the nearest tag reachable from the release commit
+   (`git describe --tags --abbrev=0`). Reachability matters — on a maintenance branch the newest
+   tag in the repository is usually *not* an ancestor, and comparing against it would be wrong.
+   If that tag turns out to point at the release commit itself — which happens when a release is
+   re-run after its tag was created — the action steps back to the release before it, rather than
+   comparing the commit with itself and reporting no changes.
+2. Runs `git diff -U3 <baseline>..<head>` restricted to files that can declare rule properties.
+3. Flags a changed line when it is not an `import`/`using` line **and** either
+   - declares a rule property itself, or
+   - edits a declaration attribute (`key`, `defaultValue`, `description`, `type`, `paramKey`)
+     inside a hunk that shows the declaration.
+
+## Conventions recognised
+
+Analyzers do not declare rule properties the same way, so the action carries one rule per
+convention:
+
+| Pattern                                    | Files                  | Analyzers |
+|--------------------------------------------|------------------------|-----------|
+| `@RuleProperty(`                            | `*.java`, `*.kt`       | sonar-python, sonar-java, sonar-go, sonar-iac, sonar-kotlin, … |
+| `new RuleParameter(`                        | `*.java`, `*.kt`       | sonar-swift, sonar-dart (central `*RulesDefinition.java`) |
+| `[RuleParameter(`                           | `*.cs`                 | sonar-dotnet-enterprise |
+| `field:` / `default:` / `displayName:`      | `*/rules/*/config.ts`  | SonarJS |
+
+SonarJS is the reason the TypeScript rule exists: its `@RuleProperty` Java classes are generated
+and **gitignored**, so they never appear in a diff. The tracked declaration is the `config.ts`
+the classes are generated from.
+
+Anything not covered can be added per repository through `extra-patterns`.
+
+## Why not just grep the diff for `RuleProperty`?
+
+Because `import org.sonar.check.RuleProperty;` shows up as diff *context* whenever an unrelated
+import is added to a check class. Replaying a plain grep over 35 real release-tag pairs across
+sonar-python, sonar-go, sonar-iac, sonar-java and SonarJS produced 8 false-positive files. The
+changed-line matcher above reports the same history with no false positives.
+
+## Inputs
+
+| Input                  | Description                                                                                                   | Required | Default  |
+|------------------------|---------------------------------------------------------------------------------------------------------------|----------|----------|
+| `branch`               | The branch being released, used as the checkout ref                                                            | No       | `master` |
+| `base-ref`             | Ref to compare against. Defaults to the nearest tag reachable from the release commit                          | No       | -        |
+| `head-ref`             | The commit being released                                                                                      | No       | `HEAD`   |
+| `extra-patterns`       | Extra detection rules, one `<pathspec>::<regex>` per line, appended to the built-in ruleset                    | No       | -        |
+| `include-test-sources` | Scan test sources too. Excluded by default, since changing a test fixture is not a released behaviour change   | No       | `false`  |
+
+## Outputs
+
+| Output               | Description                                                                    |
+|----------------------|--------------------------------------------------------------------------------|
+| `rule-props-changed` | `"true"` when a rule property declaration changed, `"false"` otherwise           |
+| `base-ref`           | The baseline actually compared against; empty when the repository has no tag     |
+| `match-count`        | Number of changed lines that altered a declaration                               |
+| `matched-files`      | Comma-separated files containing the changes (capped at 20)                      |
+
+## Usage
+
+```yaml
+- name: Detect Rule Property Changes
+  id: detect-rule-props
+  uses: SonarSource/release-github-actions/detect-rule-props-changed@v1
+  with:
+    branch: master
+
+- name: Use the result
+  run: echo "Rule properties changed: ${{ steps.detect-rule-props.outputs.rule-props-changed }}"
+```
+
+With an extra convention for an analyzer the built-in ruleset does not cover:
+
+```yaml
+- uses: SonarSource/release-github-actions/detect-rule-props-changed@v1
+  with:
+    extra-patterns: |
+      *.scala::@RuleParam\(
+      */rules/*/params.yaml::^\s*name:
+```
+
+The action checks out the repository itself with `fetch-depth: 0`, because the tags and the
+history back to the previous release must be present.
+
+## Limitations
+
+- **No baseline.** If no tag is reachable from the release commit (a first release), the action
+  emits a `::warning::` and reports `false` — there is nothing to compare against.
+- **Defaults held in distant constants.** A declaration such as
+  `defaultValue = "" + DEFAULT_THRESHOLD` is detected when the declaration block changes, but not
+  when only the far-away `DEFAULT_THRESHOLD` constant does.
+- **Description-only edits in `config.ts`** are not flagged, since rewording help text does not
+  change a rule's parameters.
+- The `matched-files` output is capped at 20 entries; `match-count` always reports the true total.
+
+## Testing
+
+```bash
+cd detect-rule-props-changed
+pip install pytest pytest-cov
+python -m pytest test_detect_rule_props_changed.py -v \
+  --cov=detect_rule_props_changed --cov-report=term-missing
+```
+
+The tests build throwaway git repositories and run the detector end to end, so real `git diff`
+output is exercised — including the import-context false positive taken from sonar-python history.

--- a/detect-rule-props-changed/README.md
+++ b/detect-rule-props-changed/README.md
@@ -21,6 +21,10 @@ workflow input; this action computes it instead.
    - edits a declaration attribute (`key`, `defaultValue`, `description`, `type`, `paramKey`)
      inside a hunk that shows the declaration.
 
+Deleting a check class counts. git names the target of a deletion `/dev/null`, so the removed
+declarations are attributed to the `--- a/<path>` side of the diff instead — dropping them would
+report a rule that no longer exists as no change at all.
+
 ## Fail-safe: "cannot tell" means "changed"
 
 If the comparison cannot be made, the action reports `rule-props-changed=true` — never `false` —
@@ -79,6 +83,7 @@ changed-line matcher above reports the same history with no false positives.
 | `head-ref`             | The commit being released                                                                                      | No       | `HEAD`   |
 | `extra-patterns`       | Extra detection rules, one `<pathspec>::<regex>` per line, appended to the built-in ruleset                    | No       | -        |
 | `include-test-sources` | Scan test sources too. Excluded by default, since changing a test fixture is not a released behaviour change   | No       | `false`  |
+| `repository-path`      | Inspect an existing checkout at this path and skip the action's own checkout, leaving the workspace untouched  | No       | -        |
 
 ## Outputs
 
@@ -117,7 +122,15 @@ With an extra convention for an analyzer the built-in ruleset does not cover:
 ```
 
 The action checks out the repository itself with `fetch-depth: 0`, because the tags and the
-history back to the previous release must be present.
+history back to the previous release must be present. That checkout **replaces the workspace**.
+Pass `repository-path` when the caller has already prepared a checkout — the action then inspects
+that path and skips its own checkout, so nothing in the workspace moves:
+
+```yaml
+- uses: SonarSource/release-github-actions/detect-rule-props-changed@v1
+  with:
+    repository-path: ${{ github.workspace }}/analyzer
+```
 
 ## Limitations
 

--- a/detect-rule-props-changed/README.md
+++ b/detect-rule-props-changed/README.md
@@ -21,6 +21,30 @@ workflow input; this action computes it instead.
    - edits a declaration attribute (`key`, `defaultValue`, `description`, `type`, `paramKey`)
      inside a hunk that shows the declaration.
 
+## Fail-safe: "cannot tell" means "changed"
+
+If the comparison cannot be made, the action reports `rule-props-changed=true` — never `false` —
+and sets `detection-status=assumed-changed`.
+
+The two wrong answers are not equally costly. A rule property change that reaches SQC
+unannounced is a production surprise; a spurious `Yes` on the release ticket costs one manual
+check. So every path that cannot produce an answer resolves to `true`:
+
+| Situation | Annotation |
+|---|---|
+| No release tag reachable from the release commit (first release) | `::warning::` |
+| The release tag points at the release commit and no earlier tag is reachable | `::warning::` |
+| Shallow checkout — the previous release and its history may be missing | `::warning::` |
+| `base-ref` or `head-ref` cannot be resolved | `::error::` |
+| Malformed `extra-patterns` — a requested convention is not being scanned | `::error::` |
+| `git diff` fails, git cannot be run, or the detector hits an unforeseen bug | `::error::` |
+
+The script **never exits non-zero**, deliberately. A non-zero exit writes no outputs at all, and
+an absent output reads downstream as "not changed" — exactly the answer the fallback exists to
+prevent. `action.yml` wraps the call as well, so a detector that cannot start at all still
+produces the safe outputs, and `automated-release.yml` treats anything other than an explicit
+`false` as `Yes`.
+
 ## Conventions recognised
 
 Analyzers do not declare rule properties the same way, so the action carries one rule per
@@ -58,12 +82,16 @@ changed-line matcher above reports the same history with no false positives.
 
 ## Outputs
 
-| Output               | Description                                                                    |
-|----------------------|--------------------------------------------------------------------------------|
-| `rule-props-changed` | `"true"` when a rule property declaration changed, `"false"` otherwise           |
-| `base-ref`           | The baseline actually compared against; empty when the repository has no tag     |
-| `match-count`        | Number of changed lines that altered a declaration                               |
-| `matched-files`      | Comma-separated files containing the changes (capped at 20)                      |
+| Output               | Description                                                                                     |
+|----------------------|---------------------------------------------------------------------------------------------------|
+| `rule-props-changed` | `"true"` when a rule property declaration changed **or the comparison was impossible**, `"false"` otherwise |
+| `base-ref`           | The baseline actually compared against; empty when no comparison was made                          |
+| `match-count`        | Number of changed lines that altered a declaration                                                 |
+| `matched-files`      | Comma-separated files containing the changes (capped at 20)                                        |
+| `detection-status`   | `"detected"` when the diff was compared, `"assumed-changed"` when the fallback fired                |
+
+Read `detection-status` when you need to tell a detected change from an assumed one — with the
+fallback, `rule-props-changed=true` alone does not mean anything was found.
 
 ## Usage
 
@@ -93,8 +121,6 @@ history back to the previous release must be present.
 
 ## Limitations
 
-- **No baseline.** If no tag is reachable from the release commit (a first release), the action
-  emits a `::warning::` and reports `false` — there is nothing to compare against.
 - **Defaults held in distant constants.** A declaration such as
   `defaultValue = "" + DEFAULT_THRESHOLD` is detected when the declaration block changes, but not
   when only the far-away `DEFAULT_THRESHOLD` constant does.
@@ -112,4 +138,6 @@ python -m pytest test_detect_rule_props_changed.py -v \
 ```
 
 The tests build throwaway git repositories and run the detector end to end, so real `git diff`
-output is exercised — including the import-context false positive taken from sonar-python history.
+output is exercised — including the import-context false positive taken from sonar-python history
+and every fallback path, each asserting that the answer is `true` and that the process still
+exits 0.

--- a/detect-rule-props-changed/action.yml
+++ b/detect-rule-props-changed/action.yml
@@ -31,10 +31,12 @@ inputs:
 
 outputs:
   rule-props-changed:
-    description: '"true" when a rule property declaration changed, "false" otherwise.'
+    description: |
+      "true" when a rule property declaration changed, "false" otherwise. Also "true" when the
+      comparison could not be made at all, so an undetectable change is never reported as absent.
     value: ${{ steps.detect.outputs.rule-props-changed }}
   base-ref:
-    description: 'The baseline ref actually compared against; empty when no tag was found.'
+    description: 'The baseline ref actually compared against; empty when no comparison was made.'
     value: ${{ steps.detect.outputs.base-ref }}
   match-count:
     description: 'Number of changed lines that altered a rule property declaration.'
@@ -42,6 +44,11 @@ outputs:
   matched-files:
     description: 'Comma-separated files containing the changes (capped at 20).'
     value: ${{ steps.detect.outputs.matched-files }}
+  detection-status:
+    description: |
+      "detected" when the diff was actually compared, "assumed-changed" when it could not be and
+      rule-props-changed was forced to "true".
+    value: ${{ steps.detect.outputs.detection-status }}
 
 runs:
   using: 'composite'
@@ -65,11 +72,26 @@ runs:
         INPUT_HEAD_REF: ${{ inputs.head-ref }}
         INPUT_EXTRA_PATTERNS: ${{ inputs.extra-patterns }}
         INPUT_INCLUDE_TEST_SOURCES: ${{ inputs.include-test-sources }}
+        SCRIPT_PATH: ${{ github.action_path }}/detect_rule_props_changed.py
       run: |
-        python ${{ github.action_path }}/detect_rule_props_changed.py \
-          --repo "$GITHUB_WORKSPACE" \
-          --base-ref "$INPUT_BASE_REF" \
-          --head-ref "$INPUT_HEAD_REF" \
-          --extra-patterns "$INPUT_EXTRA_PATTERNS" \
-          --include-test-sources "$INPUT_INCLUDE_TEST_SOURCES" \
-          >> $GITHUB_OUTPUT
+        DETECTOR_OUTPUT="$(mktemp)"
+        # The detector already answers "changed" when it cannot compare. This covers the case
+        # where it cannot run at all -- a broken interpreter, an unreadable script -- which
+        # would otherwise write no outputs, and an empty output reads downstream as "unchanged".
+        if ! python "$SCRIPT_PATH" \
+            --repo "$GITHUB_WORKSPACE" \
+            --base-ref "$INPUT_BASE_REF" \
+            --head-ref "$INPUT_HEAD_REF" \
+            --extra-patterns "$INPUT_EXTRA_PATTERNS" \
+            --include-test-sources "$INPUT_INCLUDE_TEST_SOURCES" \
+            > "$DETECTOR_OUTPUT"; then
+          echo "::error::The rule property detector could not run. Assuming rule properties changed."
+          {
+            echo "rule-props-changed=true"
+            echo "base-ref="
+            echo "match-count=0"
+            echo "matched-files="
+            echo "detection-status=assumed-changed"
+          } > "$DETECTOR_OUTPUT"
+        fi
+        cat "$DETECTOR_OUTPUT" >> "$GITHUB_OUTPUT"

--- a/detect-rule-props-changed/action.yml
+++ b/detect-rule-props-changed/action.yml
@@ -28,6 +28,12 @@ inputs:
     description: 'Scan test sources as well. Excluded by default.'
     required: false
     default: 'false'
+  repository-path:
+    description: |
+      Path to a checkout to inspect. When set, the action analyses that path and skips its own
+      checkout, so the caller's workspace is left exactly as it was. Leave empty to have the
+      action check `branch` out into the workspace itself.
+    required: false
 
 outputs:
   rule-props-changed:
@@ -54,7 +60,10 @@ runs:
   using: 'composite'
   steps:
     # fetch-depth: 0 so the release tags and the history back to the previous one are present.
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    # Skipped when the caller points at a checkout of its own: this step replaces the whole
+    # workspace, so running it anyway would discard the very tree we were asked to inspect.
+    - if: inputs.repository-path == ''
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         ref: ${{ inputs.branch }}
         fetch-depth: 0
@@ -72,6 +81,7 @@ runs:
         INPUT_HEAD_REF: ${{ inputs.head-ref }}
         INPUT_EXTRA_PATTERNS: ${{ inputs.extra-patterns }}
         INPUT_INCLUDE_TEST_SOURCES: ${{ inputs.include-test-sources }}
+        INPUT_REPOSITORY_PATH: ${{ inputs.repository-path }}
         SCRIPT_PATH: ${{ github.action_path }}/detect_rule_props_changed.py
       run: |
         DETECTOR_OUTPUT="$(mktemp)"
@@ -79,7 +89,7 @@ runs:
         # where it cannot run at all -- a broken interpreter, an unreadable script -- which
         # would otherwise write no outputs, and an empty output reads downstream as "unchanged".
         if ! python "$SCRIPT_PATH" \
-            --repo "$GITHUB_WORKSPACE" \
+            --repo "${INPUT_REPOSITORY_PATH:-$GITHUB_WORKSPACE}" \
             --base-ref "$INPUT_BASE_REF" \
             --head-ref "$INPUT_HEAD_REF" \
             --extra-patterns "$INPUT_EXTRA_PATTERNS" \

--- a/detect-rule-props-changed/action.yml
+++ b/detect-rule-props-changed/action.yml
@@ -1,0 +1,75 @@
+name: 'Detect Rule Property Changes'
+description: |
+  Detects whether any rule property (rule parameter) declaration changed between the previous
+  release tag and the commit being released, so the Jira release ticket field does not have to
+  be answered by hand.
+author: 'SonarSource'
+
+inputs:
+  branch:
+    description: 'The branch being released, used as the checkout ref.'
+    required: false
+    default: 'master'
+  base-ref:
+    description: |
+      Ref to compare against. Defaults to the nearest tag reachable from the release commit,
+      which is the previous release on maintenance branches too.
+    required: false
+  head-ref:
+    description: 'The commit being released.'
+    required: false
+    default: 'HEAD'
+  extra-patterns:
+    description: |
+      Additional detection rules, one `<pathspec>::<regex>` per line, appended to the built-in
+      ruleset. Use for analyzers that declare rule properties in an unusual way.
+    required: false
+  include-test-sources:
+    description: 'Scan test sources as well. Excluded by default.'
+    required: false
+    default: 'false'
+
+outputs:
+  rule-props-changed:
+    description: '"true" when a rule property declaration changed, "false" otherwise.'
+    value: ${{ steps.detect.outputs.rule-props-changed }}
+  base-ref:
+    description: 'The baseline ref actually compared against; empty when no tag was found.'
+    value: ${{ steps.detect.outputs.base-ref }}
+  match-count:
+    description: 'Number of changed lines that altered a rule property declaration.'
+    value: ${{ steps.detect.outputs.match-count }}
+  matched-files:
+    description: 'Comma-separated files containing the changes (capped at 20).'
+    value: ${{ steps.detect.outputs.matched-files }}
+
+runs:
+  using: 'composite'
+  steps:
+    # fetch-depth: 0 so the release tags and the history back to the previous one are present.
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ inputs.branch }}
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      with:
+        python-version: '3.10'
+
+    - name: Detect rule property changes
+      id: detect
+      shell: bash
+      env:
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_HEAD_REF: ${{ inputs.head-ref }}
+        INPUT_EXTRA_PATTERNS: ${{ inputs.extra-patterns }}
+        INPUT_INCLUDE_TEST_SOURCES: ${{ inputs.include-test-sources }}
+      run: |
+        python ${{ github.action_path }}/detect_rule_props_changed.py \
+          --repo "$GITHUB_WORKSPACE" \
+          --base-ref "$INPUT_BASE_REF" \
+          --head-ref "$INPUT_HEAD_REF" \
+          --extra-patterns "$INPUT_EXTRA_PATTERNS" \
+          --include-test-sources "$INPUT_INCLUDE_TEST_SOURCES" \
+          >> $GITHUB_OUTPUT

--- a/detect-rule-props-changed/detect_rule_props_changed.py
+++ b/detect-rule-props-changed/detect_rule_props_changed.py
@@ -14,6 +14,12 @@ the TypeScript `config.ts` those classes are generated from.
 Matching deliberately looks at *changed* lines rather than grepping the whole diff: the
 `import org.sonar.check.RuleProperty;` line appears as diff context whenever an unrelated
 import is added to a check class, and grepping that produces frequent false positives.
+
+Detection is fail-safe. Whenever the answer cannot be computed -- no release tag to compare
+against, a shallow checkout, a failing git command, an unforeseen bug -- the detector reports
+"true" rather than "false", and never exits non-zero. The two directions of a wrong answer are
+not symmetric: a rule property change that reaches SQC unannounced is a production surprise,
+whereas an unnecessary "Yes" on the release ticket costs one manual check.
 """
 
 import argparse
@@ -21,9 +27,24 @@ import os
 import re
 import subprocess
 import sys
+import traceback
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'shared'))
 from jira_common import eprint  # noqa: E402
+
+
+class UndeterminedError(Exception):
+    """
+    Detection could not be completed, so the caller must fall back to "changed".
+
+    `severity` selects the GitHub annotation level: 'error' for a misconfiguration somebody has
+    to fix, 'warning' for a situation the detector legitimately cannot resolve, such as a first
+    release. Neither one fails the step -- blocking a release is worse than over-reporting.
+    """
+
+    def __init__(self, message, severity='warning'):
+        super().__init__(message)
+        self.severity = severity
 
 
 class DetectionRule:
@@ -85,8 +106,27 @@ def pathspec_matches(path, spec):
     return re.match(regex, path) is not None
 
 
+def single_line(value):
+    """
+    Collapse a value onto one line.
+
+    `action.yml` appends this output to `$GITHUB_OUTPUT`, where each line is a `key=value`
+    pair. A newline inside a value would therefore start a new pair, and the key such an
+    injected line would most want to set is `rule-props-changed=false`.
+
+    Length is not capped here: the only unbounded value is `matched-files`, and
+    MAX_REPORTED_FILES already bounds it by entry count. Capping by characters instead would
+    cut a genuine file list off mid-path.
+    """
+    return ' '.join(str(value).split())
+
+
 def run_git(args, cwd):
-    result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True)
+    except OSError as exc:
+        raise UndeterminedError(f'git could not be run in {cwd}: {exc}',
+                                severity='error') from exc
     return result.returncode, result.stdout, result.stderr
 
 
@@ -95,22 +135,42 @@ def commit_of(repo, ref):
     return out.strip() if code == 0 else None
 
 
+def check_repository(repo, head_ref):
+    """Reject checkouts that cannot support a trustworthy diff, before any comparison."""
+    if commit_of(repo, head_ref) is None:
+        raise UndeterminedError(
+            f"head-ref '{head_ref}' cannot be resolved, so {repo} is not a usable git checkout.",
+            severity='error')
+
+    # A shallow clone can hide both the tags and the history back to the previous release, so a
+    # diff computed inside it would be silently incomplete rather than wrong-and-obvious.
+    code, out, _ = run_git(['rev-parse', '--is-shallow-repository'], repo)
+    if code == 0 and out.strip() == 'true':
+        raise UndeterminedError(
+            'the checkout is shallow, so the previous release tag and the history back to it '
+            'may be missing. Check the repository out with fetch-depth: 0.')
+
+
 def resolve_base_ref(repo, head_ref, explicit_base):
     """
-    Return the ref to diff against, or None when the repository has no prior release.
+    Return the ref to diff against.
 
     Without an explicit base we take the nearest tag reachable from HEAD, which stays
     correct on maintenance branches where the newest tag overall is not an ancestor.
+    Raises UndeterminedError when no usable baseline exists.
     """
     if explicit_base:
         if commit_of(repo, explicit_base) is None:
-            eprint(f"::error::base-ref '{explicit_base}' cannot be resolved.")
-            sys.exit(1)
+            raise UndeterminedError(
+                f"base-ref '{explicit_base}' cannot be resolved in this checkout.",
+                severity='error')
         return explicit_base
 
     code, out, _ = run_git(['describe', '--tags', '--abbrev=0', head_ref], repo)
     if code != 0 or not out.strip():
-        return None
+        raise UndeterminedError(
+            f'no release tag is reachable from {head_ref}, so there is no previous release to '
+            f'compare against.')
     tag = out.strip()
 
     # On a re-run the release tag already exists and points at the commit being released.
@@ -120,31 +180,41 @@ def resolve_base_ref(repo, head_ref, explicit_base):
                f"stepping back to the release before it.")
         code, out, _ = run_git(['describe', '--tags', '--abbrev=0', f'{tag}^'], repo)
         if code != 0 or not out.strip():
-            return None
+            raise UndeterminedError(
+                f'tag {tag} points at the release commit and no earlier release tag is '
+                f'reachable from it, so there is nothing to compare against.')
         return out.strip()
 
     return tag
 
 
 def parse_extra_patterns(raw):
-    """Parse `<pathspec>::<regex>` lines into additional detection rules."""
+    """
+    Parse `<pathspec>::<regex>` lines into additional detection rules.
+
+    A malformed line means the repository asked for a convention we are then not scanning for,
+    so it is treated as undetermined rather than quietly ignored.
+    """
     rules = []
     for lineno, line in enumerate(raw.splitlines(), start=1):
         line = line.strip()
         if not line or line.startswith('#'):
             continue
         if '::' not in line:
-            eprint(f"::error::extra-patterns line {lineno} is not '<pathspec>::<regex>': {line}")
-            sys.exit(1)
+            raise UndeterminedError(
+                f"extra-patterns line {lineno} is not '<pathspec>::<regex>': {line}",
+                severity='error')
         pathspec, pattern = (part.strip() for part in line.split('::', 1))
         if not pathspec or not pattern:
-            eprint(f"::error::extra-patterns line {lineno} has an empty pathspec or regex: {line}")
-            sys.exit(1)
+            raise UndeterminedError(
+                f'extra-patterns line {lineno} has an empty pathspec or regex: {line}',
+                severity='error')
         try:
             rules.append(DetectionRule(f'extra:{pathspec}', [pathspec], pattern))
         except re.error as exc:
-            eprint(f"::error::extra-patterns line {lineno} has an invalid regex: {exc}")
-            sys.exit(1)
+            raise UndeterminedError(
+                f'extra-patterns line {lineno} has an invalid regex: {exc}',
+                severity='error') from exc
     return rules
 
 
@@ -248,8 +318,8 @@ def detect(repo, base_ref, head_ref, rules, include_test_sources):
     code, out, err = run_git(
         ['diff', '-U3', f'{base_ref}..{head_ref}', '--'] + pathspecs, repo)
     if code != 0:
-        eprint(f"::error::git diff {base_ref}..{head_ref} failed: {err.strip()}")
-        sys.exit(1)
+        raise UndeterminedError(
+            f'git diff {base_ref}..{head_ref} failed: {err.strip()}', severity='error')
     return find_matches(out.splitlines(), rules)
 
 
@@ -276,11 +346,20 @@ def report(matches, base_ref):
     return files
 
 
-def emit(rule_props_changed, base_ref, matches, files):
+def emit(rule_props_changed, base_ref, matches, files, fallback_reason=''):
     print(f"rule-props-changed={'true' if rule_props_changed else 'false'}")
-    print(f"base-ref={base_ref}")
+    print(f"base-ref={single_line(base_ref)}")
     print(f"match-count={len(matches)}")
-    print(f"matched-files={','.join(files[:MAX_REPORTED_FILES])}")
+    print(f"matched-files={single_line(','.join(files[:MAX_REPORTED_FILES]))}")
+    print(f"detection-status={'assumed-changed' if fallback_reason else 'detected'}")
+
+
+def fall_back(error):
+    """Emit the safe answer when the comparison could not be made: assume properties changed."""
+    eprint(f'::{error.severity}::Cannot determine whether rule properties changed: {error} '
+           f'Assuming they DID change, so the release ticket errs on the safe side. '
+           f'Check the diff by hand before releasing.')
+    emit(True, '', [], [], fallback_reason=str(error))
 
 
 def main():
@@ -297,19 +376,25 @@ def main():
     args = parser.parse_args()
 
     include_test_sources = args.include_test_sources.strip().lower() == 'true'
-    rules = RULESET + parse_extra_patterns(args.extra_patterns)
 
-    base_ref = resolve_base_ref(args.repo, args.head_ref, args.base_ref.strip())
-    if base_ref is None:
-        eprint('::warning::No release tag reachable from HEAD, so there is no baseline to '
-               'diff against. Reporting no rule property changes.')
-        emit(False, '', [], [])
+    try:
+        rules = RULESET + parse_extra_patterns(args.extra_patterns)
+        check_repository(args.repo, args.head_ref)
+        base_ref = resolve_base_ref(args.repo, args.head_ref, args.base_ref.strip())
+        eprint(f"Comparing {base_ref}..{args.head_ref} for rule property changes "
+               f"(test sources {'included' if include_test_sources else 'excluded'}).")
+        matches = detect(args.repo, base_ref, args.head_ref, rules, include_test_sources)
+    except UndeterminedError as exc:
+        fall_back(exc)
+        return
+    except Exception as exc:  # noqa: BLE001
+        # An unforeseen bug must not get to decide the answer by crashing: a non-zero exit
+        # writes no outputs at all, which the workflow would read as "not changed".
+        traceback.print_exc(file=sys.stderr)
+        fall_back(UndeterminedError(f'the detector raised {type(exc).__name__}: {exc}',
+                                    severity='error'))
         return
 
-    eprint(f"Comparing {base_ref}..{args.head_ref} for rule property changes "
-           f"(test sources {'included' if include_test_sources else 'excluded'}).")
-
-    matches = detect(args.repo, base_ref, args.head_ref, rules, include_test_sources)
     files = report(matches, base_ref)
     emit(bool(matches), base_ref, matches, files)
 

--- a/detect-rule-props-changed/detect_rule_props_changed.py
+++ b/detect-rule-props-changed/detect_rule_props_changed.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Detect whether any rule property (a.k.a. rule parameter) declaration changed between the
+previous release and the commit being released.
+
+The result feeds the "Rule Properties Changed" field (customfield_11263) on the Jira REL
+ticket, which used to be answered by hand via the `rule-props-changed` workflow input.
+
+Analyzers do not agree on how rule properties are declared, so the detector carries one
+rule per convention (see RULESET below). Notably, SonarJS generates its `@RuleProperty`
+Java classes and gitignores them, so the only declaration that ever shows up in a diff is
+the TypeScript `config.ts` those classes are generated from.
+
+Matching deliberately looks at *changed* lines rather than grepping the whole diff: the
+`import org.sonar.check.RuleProperty;` line appears as diff context whenever an unrelated
+import is added to a check class, and grepping that produces frequent false positives.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'shared'))
+from jira_common import eprint  # noqa: E402
+
+
+class DetectionRule:
+    """A file selector plus the regex identifying a rule-property declaration in it."""
+
+    def __init__(self, name, pathspecs, pattern):
+        self.name = name
+        self.pathspecs = pathspecs
+        self.regex = re.compile(pattern)
+
+    def matches_file(self, path):
+        return any(pathspec_matches(path, spec) for spec in self.pathspecs)
+
+
+# One entry per declaration convention found across the analyzers.
+RULESET = [
+    # sonar-python, sonar-java, sonar-go, sonar-iac, sonar-kotlin, ...
+    DetectionRule('annotation', ['*.java', '*.kt'], r'@RuleProperty\s*\('),
+    # sonar-swift, sonar-dart: parameters listed centrally in a *RulesDefinition.java
+    DetectionRule('rule-parameter-ctor', ['*.java', '*.kt'], r'\bnew\s+RuleParameter\s*\('),
+    # sonar-dotnet-enterprise
+    DetectionRule('csharp-attribute', ['*.cs'], r'\[\s*RuleParameter\s*\('),
+    # SonarJS: ESLintConfiguration fields; the generated Java equivalents are gitignored
+    DetectionRule('eslint-config', ['*/rules/*/config.ts'],
+                  r'^\s*(field|default|displayName)\s*:'),
+]
+
+# An attribute of a declaration, e.g. `defaultValue = "10"`. Only counted inside a hunk that
+# also shows the declaration itself, so an unrelated `MESSAGE = "..."` nearby cannot trigger it.
+ATTRIBUTE_REGEX = re.compile(r'\b(key|defaultValue|description|type|paramKey)\s*=')
+
+# Import lines never constitute a rule-property change, even though they name the symbol.
+IMPORT_REGEX = re.compile(r'^\s*(import|using|from)\b')
+
+# Test sources declare rule properties too, but changing them is not a released behaviour change.
+TEST_EXCLUDE_PATHSPECS = [
+    ':(exclude)*/src/test/*',
+    ':(exclude)*/src/integrationTest/*',
+    ':(exclude)*/its/*',
+    ':(exclude)*Test.java',
+    ':(exclude)*Test.kt',
+    ':(exclude)*Test.cs',
+    ':(exclude)*Tests.cs',
+]
+
+HUNK_HEADER_REGEX = re.compile(r'^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@')
+
+MAX_REPORTED_FILES = 20
+
+
+def pathspec_matches(path, spec):
+    """
+    Match a git pathspec glob against a repository-relative path.
+
+    Unlike fnmatch, `*` here also spans `/`, so `*.java` matches a nested file and
+    `*/rules/*/config.ts` matches at any depth -- the semantics git itself applies.
+    """
+    regex = '^' + '.*'.join(re.escape(part) for part in spec.split('*')) + '$'
+    return re.match(regex, path) is not None
+
+
+def run_git(args, cwd):
+    result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True)
+    return result.returncode, result.stdout, result.stderr
+
+
+def commit_of(repo, ref):
+    code, out, _ = run_git(['rev-parse', '--verify', f'{ref}^{{commit}}'], repo)
+    return out.strip() if code == 0 else None
+
+
+def resolve_base_ref(repo, head_ref, explicit_base):
+    """
+    Return the ref to diff against, or None when the repository has no prior release.
+
+    Without an explicit base we take the nearest tag reachable from HEAD, which stays
+    correct on maintenance branches where the newest tag overall is not an ancestor.
+    """
+    if explicit_base:
+        if commit_of(repo, explicit_base) is None:
+            eprint(f"::error::base-ref '{explicit_base}' cannot be resolved.")
+            sys.exit(1)
+        return explicit_base
+
+    code, out, _ = run_git(['describe', '--tags', '--abbrev=0', head_ref], repo)
+    if code != 0 or not out.strip():
+        return None
+    tag = out.strip()
+
+    # On a re-run the release tag already exists and points at the commit being released.
+    # Comparing it with itself would report no changes, so step back one release.
+    if commit_of(repo, tag) == commit_of(repo, head_ref):
+        eprint(f"Tag {tag} already points at the release commit (re-run?); "
+               f"stepping back to the release before it.")
+        code, out, _ = run_git(['describe', '--tags', '--abbrev=0', f'{tag}^'], repo)
+        if code != 0 or not out.strip():
+            return None
+        return out.strip()
+
+    return tag
+
+
+def parse_extra_patterns(raw):
+    """Parse `<pathspec>::<regex>` lines into additional detection rules."""
+    rules = []
+    for lineno, line in enumerate(raw.splitlines(), start=1):
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        if '::' not in line:
+            eprint(f"::error::extra-patterns line {lineno} is not '<pathspec>::<regex>': {line}")
+            sys.exit(1)
+        pathspec, pattern = (part.strip() for part in line.split('::', 1))
+        if not pathspec or not pattern:
+            eprint(f"::error::extra-patterns line {lineno} has an empty pathspec or regex: {line}")
+            sys.exit(1)
+        try:
+            rules.append(DetectionRule(f'extra:{pathspec}', [pathspec], pattern))
+        except re.error as exc:
+            eprint(f"::error::extra-patterns line {lineno} has an invalid regex: {exc}")
+            sys.exit(1)
+    return rules
+
+
+def collect_pathspecs(rules, include_test_sources):
+    pathspecs = []
+    for rule in rules:
+        for spec in rule.pathspecs:
+            if spec not in pathspecs:
+                pathspecs.append(spec)
+    if not include_test_sources:
+        pathspecs += TEST_EXCLUDE_PATHSPECS
+    return pathspecs
+
+
+def iter_hunks(diff_lines):
+    """
+    Yield (path, hunk_lines) for every hunk in a unified diff.
+
+    Hunk bodies are consumed using the line counts in the `@@` header rather than by
+    looking for the next marker, so added content that itself looks like a diff header
+    (`+++ foo`) cannot desynchronise the parse.
+    """
+    current_file = None
+    index, total = 0, len(diff_lines)
+
+    while index < total:
+        line = diff_lines[index]
+
+        if line.startswith('diff --git '):
+            current_file = None
+            index += 1
+            continue
+
+        if line.startswith('+++ '):
+            path = line[4:].strip()
+            if path == '/dev/null':
+                current_file = None
+            else:
+                current_file = path[2:] if path.startswith('b/') else path
+            index += 1
+            continue
+
+        header = HUNK_HEADER_REGEX.match(line)
+        if not header:
+            index += 1
+            continue
+
+        remaining_old = int(header.group(1)) if header.group(1) is not None else 1
+        remaining_new = int(header.group(2)) if header.group(2) is not None else 1
+        body = []
+        index += 1
+
+        while index < total and (remaining_old > 0 or remaining_new > 0):
+            body_line = diff_lines[index]
+            sign = body_line[:1]
+            if sign == '+':
+                remaining_new -= 1
+            elif sign == '-':
+                remaining_old -= 1
+            elif sign == ' ' or body_line == '':
+                remaining_old -= 1
+                remaining_new -= 1
+            elif sign == '\\':  # "\ No newline at end of file"
+                pass
+            else:
+                break
+            body.append(body_line)
+            index += 1
+
+        if current_file:
+            yield current_file, body
+
+
+def find_matches(diff_lines, rules):
+    """
+    Return [(path, changed_line)] for every changed line that alters a rule property.
+
+    A line counts when it is not an import and either declares a rule property itself, or
+    edits a declaration attribute within a hunk that shows the declaration.
+    """
+    matches = []
+    for path, hunk in iter_hunks(diff_lines):
+        applicable = [rule for rule in rules if rule.matches_file(path)]
+        if not applicable:
+            continue
+
+        texts = [line[1:] if line[:1] in ' +-' else line for line in hunk]
+        has_marker = any(rule.regex.search(text) for text in texts for rule in applicable)
+
+        for line, text in zip(hunk, texts):
+            if line[:1] not in '+-' or IMPORT_REGEX.match(text):
+                continue
+            declares = any(rule.regex.search(text) for rule in applicable)
+            if declares or (has_marker and ATTRIBUTE_REGEX.search(text)):
+                matches.append((path, line.rstrip()))
+    return matches
+
+
+def detect(repo, base_ref, head_ref, rules, include_test_sources):
+    pathspecs = collect_pathspecs(rules, include_test_sources)
+    code, out, err = run_git(
+        ['diff', '-U3', f'{base_ref}..{head_ref}', '--'] + pathspecs, repo)
+    if code != 0:
+        eprint(f"::error::git diff {base_ref}..{head_ref} failed: {err.strip()}")
+        sys.exit(1)
+    return find_matches(out.splitlines(), rules)
+
+
+def report(matches, base_ref):
+    """Log a human-readable breakdown to stderr and return the affected files, in order."""
+    files = []
+    for path, _ in matches:
+        if path not in files:
+            files.append(path)
+
+    if not matches:
+        eprint(f"✅ No rule property changes found between {base_ref} and the release commit.")
+        return files
+
+    eprint(f"🔎 Found {len(matches)} rule property change(s) across {len(files)} file(s) "
+           f"since {base_ref}:")
+    for path in files[:MAX_REPORTED_FILES]:
+        eprint(f"  {path}")
+        for match_path, line in matches:
+            if match_path == path:
+                eprint(f"    {line}")
+    if len(files) > MAX_REPORTED_FILES:
+        eprint(f"  ... and {len(files) - MAX_REPORTED_FILES} more file(s)")
+    return files
+
+
+def emit(rule_props_changed, base_ref, matches, files):
+    print(f"rule-props-changed={'true' if rule_props_changed else 'false'}")
+    print(f"base-ref={base_ref}")
+    print(f"match-count={len(matches)}")
+    print(f"matched-files={','.join(files[:MAX_REPORTED_FILES])}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Detect rule property changes between the previous release and HEAD.')
+    parser.add_argument('--repo', default='.', help='Path to the git repository.')
+    parser.add_argument('--base-ref', default='',
+                        help='Baseline ref. Defaults to the nearest tag reachable from HEAD.')
+    parser.add_argument('--head-ref', default='HEAD', help='The commit being released.')
+    parser.add_argument('--extra-patterns', default='',
+                        help="Newline-separated '<pathspec>::<regex>' detection rules.")
+    parser.add_argument('--include-test-sources', default='false',
+                        help='Set to "true" to scan test sources as well.')
+    args = parser.parse_args()
+
+    include_test_sources = args.include_test_sources.strip().lower() == 'true'
+    rules = RULESET + parse_extra_patterns(args.extra_patterns)
+
+    base_ref = resolve_base_ref(args.repo, args.head_ref, args.base_ref.strip())
+    if base_ref is None:
+        eprint('::warning::No release tag reachable from HEAD, so there is no baseline to '
+               'diff against. Reporting no rule property changes.')
+        emit(False, '', [], [])
+        return
+
+    eprint(f"Comparing {base_ref}..{args.head_ref} for rule property changes "
+           f"(test sources {'included' if include_test_sources else 'excluded'}).")
+
+    matches = detect(args.repo, base_ref, args.head_ref, rules, include_test_sources)
+    files = report(matches, base_ref)
+    emit(bool(matches), base_ref, matches, files)
+
+
+if __name__ == '__main__':
+    main()

--- a/detect-rule-props-changed/detect_rule_props_changed.py
+++ b/detect-rule-props-changed/detect_rule_props_changed.py
@@ -121,6 +121,16 @@ def single_line(value):
     return ' '.join(str(value).split())
 
 
+def path_from_diff_header(value, prefix):
+    """
+    Return the repository-relative path named by a `---`/`+++` diff header, or None for
+    /dev/null, which is what git writes for the missing side of an addition or a deletion.
+    """
+    if value == '/dev/null':
+        return None
+    return value[len(prefix):] if value.startswith(prefix) else value
+
+
 def run_git(args, cwd):
     try:
         result = subprocess.run(['git'] + args, cwd=cwd, capture_output=True, text=True)
@@ -236,8 +246,13 @@ def iter_hunks(diff_lines):
     Hunk bodies are consumed using the line counts in the `@@` header rather than by
     looking for the next marker, so added content that itself looks like a diff header
     (`+++ foo`) cannot desynchronise the parse.
+
+    A deleted file has `+++ /dev/null` as its target, so the hunk is attributed to the
+    `--- a/<path>` source instead. Deleting a check class is a legitimate way for rule
+    properties to disappear; dropping those hunks would report a real removal as no change.
     """
     current_file = None
+    source_file = None
     index, total = 0, len(diff_lines)
 
     while index < total:
@@ -245,15 +260,17 @@ def iter_hunks(diff_lines):
 
         if line.startswith('diff --git '):
             current_file = None
+            source_file = None
+            index += 1
+            continue
+
+        if line.startswith('--- '):
+            source_file = path_from_diff_header(line[4:].strip(), 'a/')
             index += 1
             continue
 
         if line.startswith('+++ '):
-            path = line[4:].strip()
-            if path == '/dev/null':
-                current_file = None
-            else:
-                current_file = path[2:] if path.startswith('b/') else path
+            current_file = path_from_diff_header(line[4:].strip(), 'b/') or source_file
             index += 1
             continue
 

--- a/detect-rule-props-changed/test_detect_rule_props_changed.py
+++ b/detect-rule-props-changed/test_detect_rule_props_changed.py
@@ -87,6 +87,9 @@ class DetectorTestCase(unittest.TestCase):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(content)
 
+    def delete(self, relative_path):
+        (self.repo / relative_path).unlink()
+
     def commit(self, message='change'):
         git(self.repo, 'add', '-A')
         git(self.repo, 'commit', '-q', '-m', message)
@@ -183,6 +186,27 @@ class TestJavaAnnotation(DetectorTestCase):
         self.write('README.md', 'unrelated\n')
         self.commit()
         self.assertNotDetected()
+
+    def test_deleted_check_class_is_detected(self):
+        """
+        Dropping a rule removes its properties just as surely as editing the annotation. The
+        deletion side of the diff is the only place those lines appear, and git labels the
+        target `/dev/null`, so a parser keyed only off `+++` reports a real removal as no change.
+        """
+        self.delete(self.path)
+        self.commit('remove the check entirely')
+        matches = self.assertDetected()
+        self.assertTrue(all(path == self.path for path, _ in matches), matches)
+
+    def test_deleted_file_without_a_property_is_not_detected(self):
+        """Deleting a check that declares no properties is not a rule property change."""
+        plain = 'plain/src/main/java/org/sonar/python/checks/PlainCheck.java'
+        self.write(plain, '@Rule(key = "S200")\npublic class PlainCheck {\n}\n')
+        self.commit('add a check with no properties')
+        self.tag_baseline('1.0.0.101')
+        self.delete(plain)
+        self.commit('remove it again')
+        self.assertFalse(self.run_detect(base_ref='1.0.0.101'))
 
 
 class TestOtherConventions(DetectorTestCase):
@@ -510,6 +534,24 @@ class TestHunkParsing(unittest.TestCase):
         self.assertEqual(hunks[0], ('A.java', [' context', '+++ not a header']))
         self.assertEqual(hunks[1], ('B.java', ['-x', '+y']))
 
+    def test_removed_line_resembling_a_source_header_does_not_desync(self):
+        """The mirror of the above: a body line rendering as '--- x' is content, not a header."""
+        diff = ['diff --git a/A.java b/A.java',
+                '--- a/A.java',
+                '+++ b/A.java',
+                '@@ -1,2 +1,1 @@',
+                '--- not a header',
+                ' context',
+                'diff --git a/B.java b/B.java',
+                '--- a/B.java',
+                '+++ b/B.java',
+                '@@ -1 +1 @@',
+                '-x',
+                '+y']
+        hunks = list(iter_hunks(diff))
+        self.assertEqual(hunks[0], ('A.java', ['--- not a header', ' context']))
+        self.assertEqual(hunks[1], ('B.java', ['-x', '+y']))
+
     def test_no_newline_marker_is_not_counted(self):
         diff = ['+++ b/A.java',
                 '@@ -1 +1 @@',
@@ -530,13 +572,41 @@ class TestHunkParsing(unittest.TestCase):
         self.assertEqual(path, 'A.java')
         self.assertEqual(body, [' context'])
 
-    def test_deleted_file_target_is_skipped(self):
+    def test_deleted_file_is_attributed_to_its_old_path(self):
+        """`+++ /dev/null` is a deletion, and its removed lines are the rule properties."""
         diff = ['diff --git a/A.java b/A.java',
                 '--- a/A.java',
                 '+++ /dev/null',
                 '@@ -1 +0,0 @@',
                 '-@RuleProperty(key = "x")']
-        self.assertEqual(list(iter_hunks(diff)), [])
+        self.assertEqual(list(iter_hunks(diff)),
+                         [('A.java', ['-@RuleProperty(key = "x")'])])
+
+    def test_added_file_is_attributed_to_its_new_path(self):
+        """The mirror image: `--- /dev/null` must not leak into the following hunk's path."""
+        diff = ['diff --git a/A.java b/A.java',
+                '--- /dev/null',
+                '+++ b/A.java',
+                '@@ -0,0 +1 @@',
+                '+@RuleProperty(key = "x")']
+        self.assertEqual(list(iter_hunks(diff)),
+                         [('A.java', ['+@RuleProperty(key = "x")'])])
+
+    def test_old_path_does_not_carry_over_to_the_next_file(self):
+        """A deletion followed by another file must not attribute the second hunk to the first."""
+        diff = ['diff --git a/A.java b/A.java',
+                '--- a/A.java',
+                '+++ /dev/null',
+                '@@ -1 +0,0 @@',
+                '-@RuleProperty(key = "x")',
+                'diff --git a/B.java b/B.java',
+                '+++ b/B.java',
+                '@@ -1 +1 @@',
+                '-old',
+                '+new']
+        self.assertEqual(list(iter_hunks(diff)),
+                         [('A.java', ['-@RuleProperty(key = "x")']),
+                          ('B.java', ['-old', '+new'])])
 
 
 class TestMatchingRules(unittest.TestCase):

--- a/detect-rule-props-changed/test_detect_rule_props_changed.py
+++ b/detect-rule-props-changed/test_detect_rule_props_changed.py
@@ -1,0 +1,649 @@
+"""
+Unit tests for detect_rule_props_changed.
+
+Each detection test builds a throwaway git repository, tags a baseline, applies a change and
+runs the detector end to end. Exercising real `git diff` output is the point: the matcher's
+whole job is to tell genuine declaration changes apart from diff noise, and hand-written diff
+fixtures would not reproduce the hunk framing that noise arrives in.
+"""
+
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from detect_rule_props_changed import (  # noqa: E402
+    ATTRIBUTE_REGEX,
+    MAX_REPORTED_FILES,
+    RULESET,
+    DetectionRule,
+    detect,
+    emit,
+    find_matches,
+    iter_hunks,
+    main,
+    parse_extra_patterns,
+    pathspec_matches,
+    report,
+    resolve_base_ref,
+)
+
+BASELINE_TAG = '1.0.0.100'
+
+# A check class as the Java analyzers write them: the annotation, and an import of it.
+JAVA_CHECK = """\
+package org.sonar.python.checks;
+
+import java.util.regex.Pattern;
+import org.sonar.check.Rule;
+import org.sonar.check.RuleProperty;
+
+@Rule(key = "S100")
+public class NamingCheck {
+
+  private static final String MESSAGE = "Rename this.";
+
+  @RuleProperty(
+    key = "format",
+    description = "Regular expression the names are checked against.",
+    defaultValue = "^[a-z][a-zA-Z0-9]*$")
+  public String format = "^[a-z][a-zA-Z0-9]*$";
+
+  public void check() {
+    Pattern.compile(format);
+  }
+}
+"""
+
+
+def git(repo, *args):
+    subprocess.run(['git'] + list(args), cwd=repo, check=True,
+                   capture_output=True, text=True)
+
+
+class DetectorTestCase(unittest.TestCase):
+    """Base class providing a scratch git repository with a tagged baseline."""
+
+    def setUp(self):
+        self._tmp = TemporaryDirectory()
+        self.repo = Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+        git(self.repo, 'init', '-q', '-b', 'master')
+        git(self.repo, 'config', 'user.email', 'test@example.com')
+        git(self.repo, 'config', 'user.name', 'Test')
+        git(self.repo, 'config', 'commit.gpgsign', 'false')
+
+    def write(self, relative_path, content):
+        path = self.repo / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+    def commit(self, message='change'):
+        git(self.repo, 'add', '-A')
+        git(self.repo, 'commit', '-q', '-m', message)
+
+    def tag_baseline(self, tag=BASELINE_TAG):
+        git(self.repo, 'tag', tag)
+
+    def run_detect(self, include_test_sources=False, rules=None, base_ref=BASELINE_TAG):
+        return detect(str(self.repo), base_ref, 'HEAD',
+                      rules if rules is not None else RULESET, include_test_sources)
+
+    def assertDetected(self, msg=''):
+        matches = self.run_detect()
+        self.assertTrue(matches, msg or f'expected a detection, got none. {matches}')
+        return matches
+
+    def assertNotDetected(self, msg=''):
+        matches = self.run_detect()
+        self.assertFalse(matches, msg or f'expected no detection, got {matches}')
+
+
+class TestJavaAnnotation(DetectorTestCase):
+    """The @RuleProperty convention used by sonar-python, sonar-java, sonar-go, sonar-iac."""
+
+    def setUp(self):
+        super().setUp()
+        self.path = 'checks/src/main/java/org/sonar/python/checks/NamingCheck.java'
+        self.write(self.path, JAVA_CHECK)
+        self.commit('baseline')
+        self.tag_baseline()
+
+    def test_added_property_is_detected(self):
+        self.write(self.path, JAVA_CHECK.replace(
+            '  public void check() {',
+            '  @RuleProperty(key = "maximum", defaultValue = "10")\n'
+            '  public int maximum = 10;\n\n'
+            '  public void check() {'))
+        self.commit()
+        self.assertDetected()
+
+    def test_removed_property_is_detected(self):
+        without_property = JAVA_CHECK.replace(
+            '  @RuleProperty(\n'
+            '    key = "format",\n'
+            '    description = "Regular expression the names are checked against.",\n'
+            '    defaultValue = "^[a-z][a-zA-Z0-9]*$")\n', '')
+        self.assertNotEqual(without_property, JAVA_CHECK, 'fixture replacement did not apply')
+        self.write(self.path, without_property)
+        self.commit()
+        self.assertDetected()
+
+    def test_renamed_property_key_is_detected(self):
+        """The real sonar-java 8.25 -> 8.26 change: noavThreshold -> nodvThreshold."""
+        self.write(self.path, JAVA_CHECK.replace('key = "format"', 'key = "namingFormat"'))
+        self.commit()
+        self.assertDetected()
+
+    def test_changed_default_value_is_detected(self):
+        """The attribute rule: only the defaultValue line moves, not the annotation itself."""
+        self.write(self.path, JAVA_CHECK.replace(
+            'defaultValue = "^[a-z][a-zA-Z0-9]*$")',
+            'defaultValue = "^[A-Z][a-zA-Z0-9]*$")'))
+        self.commit()
+        matches = self.assertDetected()
+        self.assertTrue(any('defaultValue' in line for _, line in matches))
+
+    def test_added_import_near_annotation_is_not_detected(self):
+        """
+        Regression for the dominant false positive in real history: adding an unrelated import
+        puts `import org.sonar.check.RuleProperty;` in the hunk as context.
+        """
+        self.write(self.path, JAVA_CHECK.replace(
+            'import java.util.regex.Pattern;',
+            'import java.util.List;\nimport java.util.regex.Pattern;'))
+        self.commit()
+        self.assertNotDetected()
+
+    def test_unrelated_constant_near_annotation_is_not_detected(self):
+        """A constant three lines above the annotation shares its hunk but is not a property."""
+        self.write(self.path, JAVA_CHECK.replace(
+            'private static final String MESSAGE = "Rename this.";',
+            'private static final String MESSAGE = "Please rename this.";'))
+        self.commit()
+        self.assertNotDetected()
+
+    def test_unrelated_body_change_is_not_detected(self):
+        self.write(self.path, JAVA_CHECK.replace(
+            'Pattern.compile(format);',
+            'Pattern.compile(format, 0);'))
+        self.commit()
+        self.assertNotDetected()
+
+    def test_no_change_at_all_is_not_detected(self):
+        self.write('README.md', 'unrelated\n')
+        self.commit()
+        self.assertNotDetected()
+
+
+class TestOtherConventions(DetectorTestCase):
+    """The non-@RuleProperty conventions: Kotlin, C#, central RuleParameter lists, SonarJS."""
+
+    def test_kotlin_annotation_is_detected(self):
+        path = 'sonar-kotlin-checks/src/main/java/org/sonarsource/kotlin/checks/LineCheck.kt'
+        self.write(path, 'class LineCheck {\n  val max = 120\n}\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path,
+                   'class LineCheck {\n'
+                   '  @RuleProperty(key = "maximumLineLength", defaultValue = "120")\n'
+                   '  val max = 120\n}\n')
+        self.commit()
+        self.assertDetected()
+
+    def test_csharp_attribute_is_detected(self):
+        """sonar-dotnet-enterprise declares parameters with a [RuleParameter] attribute."""
+        path = 'analyzers/src/SonarAnalyzer.CSharp/Rules/FunctionComplexity.cs'
+        self.write(path, 'public class FunctionComplexity\n{\n    public int Maximum { get; set; }\n}\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path,
+                   'public class FunctionComplexity\n{\n'
+                   '    [RuleParameter("threshold", PropertyType.Integer, "Max complexity.", 10)]\n'
+                   '    public int Maximum { get; set; }\n}\n')
+        self.commit()
+        self.assertDetected()
+
+    def test_central_rule_parameter_list_is_detected(self):
+        """sonar-swift and sonar-dart list every parameter in one RulesDefinition."""
+        path = 'src/main/java/com/sonarsource/dart/plugin/DartRulesDefinition.java'
+        baseline = ('public class DartRulesDefinition {\n'
+                    '  public static List<RuleParameter> parameters() {\n'
+                    '    return List.of(\n'
+                    '        new RuleParameter("S107", "max", "7", "Max params", INTEGER));\n'
+                    '  }\n}\n')
+        self.write(path, baseline)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, baseline.replace(
+            '        new RuleParameter("S107", "max", "7", "Max params", INTEGER));',
+            '        new RuleParameter("S107", "max", "7", "Max params", INTEGER),\n'
+            '        new RuleParameter("S1192", "threshold", "3", "Duplicates", INTEGER));'))
+        self.commit()
+        self.assertDetected()
+
+    def test_sonarjs_config_ts_new_field_is_detected(self):
+        """
+        SonarJS generates and gitignores its @RuleProperty classes, so config.ts is the only
+        tracked declaration. Mirrors the real 13.2 -> 13.3 'propNamePattern' addition.
+        """
+        path = 'packages/analysis/src/jsts/rules/S6478/config.ts'
+        baseline = ("import type { ESLintConfiguration } from '../helpers/configs.js';\n"
+                    'export const fields = [\n'
+                    '  [\n'
+                    '    {\n'
+                    "      field: 'allowAsProps',\n"
+                    '      default: false,\n'
+                    '    },\n'
+                    '  ],\n'
+                    '] as const satisfies ESLintConfiguration;\n')
+        self.write(path, baseline)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, baseline.replace(
+            '    },\n  ],\n',
+            '    },\n'
+            '    {\n'
+            "      field: 'propNamePattern',\n"
+            "      default: '{render*,*Enhancer}',\n"
+            '    },\n  ],\n'))
+        self.commit()
+        self.assertDetected()
+
+    def test_sonarjs_config_ts_unrelated_change_is_not_detected(self):
+        path = 'packages/analysis/src/jsts/rules/S6478/config.ts'
+        baseline = ("import type { ESLintConfiguration } from '../helpers/configs.js';\n"
+                    'const ROLES = [];\n'
+                    'export const fields = [\n'
+                    '  [\n'
+                    '    {\n'
+                    "      field: 'allowAsProps',\n"
+                    '      default: false,\n'
+                    '    },\n'
+                    '  ],\n'
+                    '] as const satisfies ESLintConfiguration;\n')
+        self.write(path, baseline)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, baseline.replace("const ROLES = [];", "const ROLES = ['listbox'];"))
+        self.commit()
+        self.assertNotDetected()
+
+    def test_non_rule_file_is_ignored(self):
+        """A .ts file outside a rules/<key>/config.ts path is not a declaration site."""
+        path = 'packages/analysis/src/jsts/helpers/configs.ts'
+        self.write(path, 'export const x = 1;\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, "export const x = 1;\nexport const field = 'format';\n")
+        self.commit()
+        self.assertNotDetected()
+
+
+class TestTestSourceHandling(DetectorTestCase):
+    def setUp(self):
+        super().setUp()
+        self.path = 'checks/src/test/java/org/sonar/python/checks/NamingCheckTest.java'
+        self.write(self.path, 'class NamingCheckTest {\n}\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(self.path,
+                   'class NamingCheckTest {\n'
+                   '  @RuleProperty(key = "format", defaultValue = "x")\n'
+                   '  String format;\n}\n')
+        self.commit()
+
+    def test_test_sources_excluded_by_default(self):
+        self.assertFalse(self.run_detect(include_test_sources=False))
+
+    def test_test_sources_included_on_request(self):
+        self.assertTrue(self.run_detect(include_test_sources=True))
+
+
+class TestBaseRefResolution(DetectorTestCase):
+    def test_nearest_reachable_tag_is_used(self):
+        self.write('a.txt', '1\n')
+        self.commit('first')
+        git(self.repo, 'tag', '1.0.0.100')
+        self.write('a.txt', '2\n')
+        self.commit('second')
+        git(self.repo, 'tag', '1.1.0.200')
+        self.write('a.txt', '3\n')
+        self.commit('third')
+        self.assertEqual(resolve_base_ref(str(self.repo), 'HEAD', ''), '1.1.0.200')
+
+    def test_maintenance_branch_ignores_newer_unreachable_tag(self):
+        """A newer tag on master must not become the baseline for a dot release."""
+        self.write('a.txt', '1\n')
+        self.commit('first')
+        git(self.repo, 'tag', '1.0.0.100')
+        git(self.repo, 'checkout', '-q', '-b', 'branch-1.0')
+        self.write('a.txt', 'fix\n')
+        self.commit('hotfix')
+        git(self.repo, 'checkout', '-q', 'master')
+        self.write('a.txt', 'next\n')
+        self.commit('feature')
+        git(self.repo, 'tag', '2.0.0.900')
+        git(self.repo, 'checkout', '-q', 'branch-1.0')
+        self.assertEqual(resolve_base_ref(str(self.repo), 'HEAD', ''), '1.0.0.100')
+
+    def test_explicit_base_ref_wins(self):
+        self.write('a.txt', '1\n')
+        self.commit('first')
+        git(self.repo, 'tag', '1.0.0.100')
+        git(self.repo, 'tag', 'custom-baseline')
+        self.assertEqual(
+            resolve_base_ref(str(self.repo), 'HEAD', 'custom-baseline'), 'custom-baseline')
+
+    def test_rerun_steps_back_past_the_release_tag(self):
+        """
+        On a re-run the release tag already points at HEAD. Comparing it against itself would
+        report no changes, so the previous release must be used instead.
+        """
+        self.write('a.txt', '1\n')
+        self.commit('first')
+        git(self.repo, 'tag', '1.0.0.100')
+        self.write('a.txt', '2\n')
+        self.commit('release commit')
+        git(self.repo, 'tag', '1.1.0.200')
+        self.assertEqual(resolve_base_ref(str(self.repo), 'HEAD', ''), '1.0.0.100')
+
+    def test_rerun_without_an_earlier_release_returns_none(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        git(self.repo, 'tag', '1.0.0.100')
+        self.assertIsNone(resolve_base_ref(str(self.repo), 'HEAD', ''))
+
+    def test_rerun_detects_changes_against_the_previous_release(self):
+        """End to end: the property change is still found when the release tag already exists."""
+        path = 'checks/src/main/java/Check.java'
+        self.write(path, JAVA_CHECK)
+        self.commit('previous release')
+        git(self.repo, 'tag', '1.0.0.100')
+        self.write(path, JAVA_CHECK.replace('key = "format"', 'key = "pattern"'))
+        self.commit('release commit')
+        git(self.repo, 'tag', '1.1.0.200')
+
+        base = resolve_base_ref(str(self.repo), 'HEAD', '')
+        self.assertTrue(self.run_detect(base_ref=base))
+
+    def test_no_tag_returns_none(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        self.assertIsNone(resolve_base_ref(str(self.repo), 'HEAD', ''))
+
+    def test_unresolvable_explicit_base_ref_exits(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        with self.assertRaises(SystemExit) as ctx:
+            resolve_base_ref(str(self.repo), 'HEAD', 'no-such-tag')
+        self.assertEqual(ctx.exception.code, 1)
+
+
+class TestExtraPatterns(unittest.TestCase):
+    def test_parses_pathspec_and_regex(self):
+        rules = parse_extra_patterns('*.scala::@RuleParam\\(')
+        self.assertEqual(len(rules), 1)
+        self.assertEqual(rules[0].pathspecs, ['*.scala'])
+        self.assertTrue(rules[0].regex.search('  @RuleParam(key = "x")'))
+
+    def test_ignores_blank_lines_and_comments(self):
+        self.assertEqual(parse_extra_patterns('\n# a comment\n\n'), [])
+
+    def test_rejects_line_without_separator(self):
+        with self.assertRaises(SystemExit):
+            parse_extra_patterns('*.scala@RuleParam')
+
+    def test_rejects_empty_side(self):
+        with self.assertRaises(SystemExit):
+            parse_extra_patterns('*.scala::')
+
+    def test_rejects_invalid_regex(self):
+        with self.assertRaises(SystemExit):
+            parse_extra_patterns('*.scala::([unclosed')
+
+
+class TestExtraPatternsDetection(DetectorTestCase):
+    def test_extra_pattern_detects_custom_convention(self):
+        path = 'src/main/scala/Check.scala'
+        self.write(path, 'class Check {\n  val max = 1\n}\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, 'class Check {\n  @RuleParam("max")\n  val max = 1\n}\n')
+        self.commit()
+        self.assertFalse(self.run_detect(), 'scala is not covered by the built-in ruleset')
+        rules = RULESET + parse_extra_patterns(r'*.scala::@RuleParam\(')
+        self.assertTrue(self.run_detect(rules=rules))
+
+
+class TestPathspecMatching(unittest.TestCase):
+    def test_star_spans_directories(self):
+        self.assertTrue(pathspec_matches('a/b/c/Check.java', '*.java'))
+        self.assertFalse(pathspec_matches('a/b/c/Check.kt', '*.java'))
+
+    def test_nested_rules_config_matches_at_any_depth(self):
+        self.assertTrue(pathspec_matches(
+            'packages/analysis/src/jsts/rules/S100/config.ts', '*/rules/*/config.ts'))
+        self.assertFalse(pathspec_matches(
+            'packages/analysis/src/jsts/helpers/config.ts', '*/rules/*/config.ts'))
+
+    def test_dot_is_literal(self):
+        self.assertFalse(pathspec_matches('Checkxjava', '*.java'))
+
+
+class TestHunkParsing(unittest.TestCase):
+    def test_single_line_hunk_without_counts(self):
+        diff = ['diff --git a/A.java b/A.java',
+                '--- a/A.java',
+                '+++ b/A.java',
+                '@@ -1 +1 @@',
+                '-old',
+                '+new']
+        self.assertEqual(list(iter_hunks(diff)), [('A.java', ['-old', '+new'])])
+
+    def test_added_line_resembling_a_file_header_does_not_desync(self):
+        """A body line rendering as '+++ x' must be consumed as content, not a new header."""
+        diff = ['diff --git a/A.java b/A.java',
+                '--- a/A.java',
+                '+++ b/A.java',
+                '@@ -1,1 +1,2 @@',
+                ' context',
+                '+++ not a header',
+                'diff --git a/B.java b/B.java',
+                '--- a/B.java',
+                '+++ b/B.java',
+                '@@ -1 +1 @@',
+                '-x',
+                '+y']
+        hunks = list(iter_hunks(diff))
+        self.assertEqual(hunks[0], ('A.java', [' context', '+++ not a header']))
+        self.assertEqual(hunks[1], ('B.java', ['-x', '+y']))
+
+    def test_no_newline_marker_is_not_counted(self):
+        diff = ['+++ b/A.java',
+                '@@ -1 +1 @@',
+                '-old',
+                '\\ No newline at end of file',
+                '+new']
+        (path, body), = list(iter_hunks(diff))
+        self.assertEqual(path, 'A.java')
+        self.assertIn('+new', body)
+
+    def test_truncated_hunk_body_stops_cleanly(self):
+        """A body shorter than its header claims must not run past the end of the diff."""
+        diff = ['+++ b/A.java',
+                '@@ -1,5 +1,5 @@',
+                ' context',
+                'garbage that is not a diff body line']
+        (path, body), = list(iter_hunks(diff))
+        self.assertEqual(path, 'A.java')
+        self.assertEqual(body, [' context'])
+
+    def test_deleted_file_target_is_skipped(self):
+        diff = ['diff --git a/A.java b/A.java',
+                '--- a/A.java',
+                '+++ /dev/null',
+                '@@ -1 +0,0 @@',
+                '-@RuleProperty(key = "x")']
+        self.assertEqual(list(iter_hunks(diff)), [])
+
+
+class TestMatchingRules(unittest.TestCase):
+    """Direct checks on the matcher, independent of git."""
+
+    @staticmethod
+    def diff(*body):
+        return ['+++ b/Check.java', f'@@ -1,{len(body)} +1,{len(body)} @@', *body]
+
+    def test_import_line_never_matches(self):
+        matches = find_matches(
+            self.diff('+import org.sonar.check.RuleProperty;'), RULESET)
+        self.assertEqual(matches, [])
+
+    def test_attribute_needs_a_declaration_in_the_hunk(self):
+        without = find_matches(self.diff('+  description = "changed";'), RULESET)
+        self.assertEqual(without, [], 'attribute alone must not match')
+
+        with_marker = find_matches(
+            self.diff(' @RuleProperty(', '+  description = "changed";', ' )'), RULESET)
+        self.assertEqual(len(with_marker), 1)
+
+    def test_file_with_no_applicable_rule_is_skipped(self):
+        diff = ['+++ b/docs/notes.md',
+                '@@ -1 +1 @@',
+                '+@RuleProperty(key = "x")']
+        self.assertEqual(find_matches(diff, RULESET), [])
+
+    def test_context_line_alone_never_matches(self):
+        self.assertEqual(find_matches(self.diff(' @RuleProperty(key = "x")'), RULESET), [])
+
+    def test_attribute_regex_ignores_unrelated_assignment(self):
+        self.assertIsNone(ATTRIBUTE_REGEX.search('String MESSAGE = "hello";'))
+        self.assertIsNotNone(ATTRIBUTE_REGEX.search('defaultValue = "10"'))
+
+
+class TestReportingAndOutput(unittest.TestCase):
+    """The stdout contract action.yml redirects into $GITHUB_OUTPUT."""
+
+    def capture(self, fn, *args):
+        stdout, stderr = StringIO(), StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            result = fn(*args)
+        return result, stdout.getvalue(), stderr.getvalue()
+
+    def test_emit_prints_every_output_key(self):
+        _, out, _ = self.capture(emit, True, '1.0.0.100', [('A.java', '+x')], ['A.java'])
+        self.assertEqual(out.splitlines(), [
+            'rule-props-changed=true',
+            'base-ref=1.0.0.100',
+            'match-count=1',
+            'matched-files=A.java',
+        ])
+
+    def test_emit_false_when_nothing_changed(self):
+        _, out, _ = self.capture(emit, False, '1.0.0.100', [], [])
+        self.assertIn('rule-props-changed=false', out)
+        self.assertIn('matched-files=', out)
+
+    def test_emit_caps_the_file_list(self):
+        files = [f'F{i}.java' for i in range(MAX_REPORTED_FILES + 5)]
+        _, out, _ = self.capture(emit, True, 'tag', [], files)
+        listed = [line for line in out.splitlines() if line.startswith('matched-files=')][0]
+        self.assertEqual(len(listed[len('matched-files='):].split(',')), MAX_REPORTED_FILES)
+
+    def test_report_deduplicates_files_and_keeps_order(self):
+        matches = [('B.java', '+b1'), ('A.java', '+a'), ('B.java', '+b2')]
+        files, _, err = self.capture(report, matches, '1.0.0.100')
+        self.assertEqual(files, ['B.java', 'A.java'])
+        self.assertIn('3 rule property change(s) across 2 file(s)', err)
+
+    def test_report_announces_a_clean_result(self):
+        files, _, err = self.capture(report, [], '1.0.0.100')
+        self.assertEqual(files, [])
+        self.assertIn('No rule property changes', err)
+
+    def test_report_truncates_long_file_lists(self):
+        matches = [(f'F{i}.java', '+x') for i in range(MAX_REPORTED_FILES + 3)]
+        _, _, err = self.capture(report, matches, 'tag')
+        self.assertIn('and 3 more file(s)', err)
+
+
+class TestMainCli(DetectorTestCase):
+    """End-to-end through main(), the entry point action.yml calls."""
+
+    def run_main(self, *extra_args):
+        argv = ['detect_rule_props_changed.py', '--repo', str(self.repo), *extra_args]
+        stdout, stderr = StringIO(), StringIO()
+        with patch.object(sys, 'argv', argv), redirect_stdout(stdout), redirect_stderr(stderr):
+            main()
+        outputs = dict(line.split('=', 1) for line in stdout.getvalue().strip().splitlines())
+        return outputs, stderr.getvalue()
+
+    def test_reports_true_for_a_real_property_change(self):
+        path = 'checks/src/main/java/Check.java'
+        self.write(path, JAVA_CHECK)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, JAVA_CHECK.replace('key = "format"', 'key = "pattern"'))
+        self.commit()
+
+        outputs, err = self.run_main()
+        self.assertEqual(outputs['rule-props-changed'], 'true')
+        self.assertEqual(outputs['base-ref'], BASELINE_TAG)
+        self.assertEqual(outputs['matched-files'], path)
+        self.assertIn('rule property change(s)', err)
+
+    def test_reports_false_and_warns_without_a_baseline_tag(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+
+        outputs, err = self.run_main()
+        self.assertEqual(outputs['rule-props-changed'], 'false')
+        self.assertEqual(outputs['base-ref'], '')
+        self.assertEqual(outputs['match-count'], '0')
+        self.assertIn('::warning::', err)
+
+    def test_include_test_sources_flag_is_honoured(self):
+        path = 'checks/src/test/java/CheckTest.java'
+        self.write(path, 'class CheckTest {}\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, 'class CheckTest {\n  @RuleProperty(key = "x")\n  String x;\n}\n')
+        self.commit()
+
+        self.assertEqual(self.run_main()[0]['rule-props-changed'], 'false')
+        outputs, _ = self.run_main('--include-test-sources', 'true')
+        self.assertEqual(outputs['rule-props-changed'], 'true')
+
+    def test_bad_diff_range_exits_with_an_error_annotation(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        stderr = StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as ctx:
+            detect(str(self.repo), 'no-such-ref', 'HEAD', RULESET, False)
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn('::error::', stderr.getvalue())
+
+
+class TestRuleset(unittest.TestCase):
+    def test_every_builtin_rule_has_a_valid_pathspec_and_name(self):
+        for rule in RULESET:
+            self.assertIsInstance(rule, DetectionRule)
+            self.assertTrue(rule.name)
+            self.assertTrue(rule.pathspecs)
+
+    def test_annotation_rule_requires_the_at_sign(self):
+        """`import ...RuleProperty;` must not satisfy the declaration regex."""
+        annotation = next(r for r in RULESET if r.name == 'annotation')
+        self.assertIsNone(annotation.regex.search('import org.sonar.check.RuleProperty;'))
+        self.assertIsNotNone(annotation.regex.search('  @RuleProperty(key = "x")'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/detect-rule-props-changed/test_detect_rule_props_changed.py
+++ b/detect-rule-props-changed/test_detect_rule_props_changed.py
@@ -23,6 +23,8 @@ from detect_rule_props_changed import (  # noqa: E402
     MAX_REPORTED_FILES,
     RULESET,
     DetectionRule,
+    UndeterminedError,
+    check_repository,
     detect,
     emit,
     find_matches,
@@ -32,6 +34,7 @@ from detect_rule_props_changed import (  # noqa: E402
     pathspec_matches,
     report,
     resolve_base_ref,
+    single_line,
 )
 
 BASELINE_TAG = '1.0.0.100'
@@ -354,11 +357,12 @@ class TestBaseRefResolution(DetectorTestCase):
         git(self.repo, 'tag', '1.1.0.200')
         self.assertEqual(resolve_base_ref(str(self.repo), 'HEAD', ''), '1.0.0.100')
 
-    def test_rerun_without_an_earlier_release_returns_none(self):
+    def test_rerun_without_an_earlier_release_is_undetermined(self):
         self.write('a.txt', '1\n')
         self.commit('only commit')
         git(self.repo, 'tag', '1.0.0.100')
-        self.assertIsNone(resolve_base_ref(str(self.repo), 'HEAD', ''))
+        with self.assertRaises(UndeterminedError):
+            resolve_base_ref(str(self.repo), 'HEAD', '')
 
     def test_rerun_detects_changes_against_the_previous_release(self):
         """End to end: the property change is still found when the release tag already exists."""
@@ -373,17 +377,53 @@ class TestBaseRefResolution(DetectorTestCase):
         base = resolve_base_ref(str(self.repo), 'HEAD', '')
         self.assertTrue(self.run_detect(base_ref=base))
 
-    def test_no_tag_returns_none(self):
+    def test_no_tag_is_undetermined(self):
         self.write('a.txt', '1\n')
         self.commit('only commit')
-        self.assertIsNone(resolve_base_ref(str(self.repo), 'HEAD', ''))
+        with self.assertRaises(UndeterminedError) as ctx:
+            resolve_base_ref(str(self.repo), 'HEAD', '')
+        self.assertIn('no release tag is reachable', str(ctx.exception))
 
-    def test_unresolvable_explicit_base_ref_exits(self):
+    def test_unresolvable_explicit_base_ref_is_undetermined(self):
         self.write('a.txt', '1\n')
         self.commit('only commit')
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(UndeterminedError) as ctx:
             resolve_base_ref(str(self.repo), 'HEAD', 'no-such-tag')
-        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(ctx.exception.severity, 'error')
+
+
+class TestRepositoryPreconditions(DetectorTestCase):
+    """Checkouts that cannot support a trustworthy diff must be caught before comparing."""
+
+    def test_usable_checkout_passes(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        self.assertIsNone(check_repository(str(self.repo), 'HEAD'))
+
+    def test_unresolvable_head_ref_is_undetermined(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        with self.assertRaises(UndeterminedError) as ctx:
+            check_repository(str(self.repo), 'no-such-branch')
+        self.assertEqual(ctx.exception.severity, 'error')
+
+    def test_shallow_checkout_is_undetermined(self):
+        """
+        A shallow clone can hide the previous release tag and the history back to it, so its
+        diff would be quietly incomplete rather than obviously broken.
+        """
+        for index in range(3):
+            self.write('a.txt', f'{index}\n')
+            self.commit(f'commit {index}')
+
+        with TemporaryDirectory() as shallow_parent:
+            shallow = Path(shallow_parent) / 'shallow'
+            subprocess.run(
+                ['git', 'clone', '-q', '--depth', '1', f'file://{self.repo}', str(shallow)],
+                check=True, capture_output=True, text=True)
+            with self.assertRaises(UndeterminedError) as ctx:
+                check_repository(str(shallow), 'HEAD')
+        self.assertIn('shallow', str(ctx.exception))
 
 
 class TestExtraPatterns(unittest.TestCase):
@@ -397,16 +437,21 @@ class TestExtraPatterns(unittest.TestCase):
         self.assertEqual(parse_extra_patterns('\n# a comment\n\n'), [])
 
     def test_rejects_line_without_separator(self):
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(UndeterminedError):
             parse_extra_patterns('*.scala@RuleParam')
 
     def test_rejects_empty_side(self):
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(UndeterminedError):
             parse_extra_patterns('*.scala::')
 
     def test_rejects_invalid_regex(self):
-        with self.assertRaises(SystemExit):
+        """
+        A pattern the repository asked for but we cannot compile means we are not scanning a
+        convention somebody expects us to scan -- undetermined, not silently ignored.
+        """
+        with self.assertRaises(UndeterminedError) as ctx:
             parse_extra_patterns('*.scala::([unclosed')
+        self.assertEqual(ctx.exception.severity, 'error')
 
 
 class TestExtraPatternsDetection(DetectorTestCase):
@@ -544,7 +589,45 @@ class TestReportingAndOutput(unittest.TestCase):
             'base-ref=1.0.0.100',
             'match-count=1',
             'matched-files=A.java',
+            'detection-status=detected',
         ])
+
+    def test_emit_marks_a_fallback_result(self):
+        _, out, _ = self.capture(emit, True, '', [], [], 'no release tag is reachable.')
+        self.assertIn('rule-props-changed=true', out)
+        self.assertIn('detection-status=assumed-changed', out)
+
+    def test_emit_keeps_every_value_on_one_line(self):
+        """
+        $GITHUB_OUTPUT is one `key=value` per line, so a newline inside a value would start a
+        new pair -- and the pair an injected line would most want to write is
+        `rule-props-changed=false`, defeating the whole fail-safe.
+        """
+        _, out, _ = self.capture(
+            emit, True, 'tag\nrule-props-changed=false', [], [],
+            'boom\nrule-props-changed=false')
+        lines = out.strip().splitlines()
+        self.assertEqual(len(lines), 5, 'no value may add a line')
+        # The injected text survives inside a value, which is harmless; what must not happen is
+        # a second line whose key is rule-props-changed.
+        self.assertEqual([line for line in lines if line.startswith('rule-props-changed=')],
+                         ['rule-props-changed=true'])
+
+    def test_single_line_leaves_a_short_value_alone(self):
+        self.assertEqual(single_line('1.0.0.100'), '1.0.0.100')
+
+    def test_emit_does_not_truncate_a_long_file_list(self):
+        """
+        MAX_REPORTED_FILES bounds this output by entry count. A character cap on top of it
+        would cut a real file list off mid-path -- three java check paths already exceed 200
+        characters, so it would fire on ordinary releases, not just pathological ones.
+        """
+        files = [f'python-checks/src/main/java/org/sonar/python/checks/RuleCheck{i}.java'
+                 for i in range(MAX_REPORTED_FILES)]
+        _, out, _ = self.capture(emit, True, '1.0.0.100', files, files)
+        emitted = next(line for line in out.splitlines() if line.startswith('matched-files='))
+        self.assertNotIn('...', emitted)
+        self.assertEqual(emitted, 'matched-files=' + ','.join(files))
 
     def test_emit_false_when_nothing_changed(self):
         _, out, _ = self.capture(emit, False, '1.0.0.100', [], [])
@@ -599,15 +682,18 @@ class TestMainCli(DetectorTestCase):
         self.assertEqual(outputs['matched-files'], path)
         self.assertIn('rule property change(s)', err)
 
-    def test_reports_false_and_warns_without_a_baseline_tag(self):
-        self.write('a.txt', '1\n')
-        self.commit('only commit')
+    def test_reports_false_for_a_release_with_no_property_change(self):
+        path = 'checks/src/main/java/Check.java'
+        self.write(path, JAVA_CHECK)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, JAVA_CHECK.replace('Pattern.compile(format);',
+                                            'Pattern.compile(format, 0);'))
+        self.commit()
 
-        outputs, err = self.run_main()
+        outputs, _ = self.run_main()
         self.assertEqual(outputs['rule-props-changed'], 'false')
-        self.assertEqual(outputs['base-ref'], '')
-        self.assertEqual(outputs['match-count'], '0')
-        self.assertIn('::warning::', err)
+        self.assertEqual(outputs['detection-status'], 'detected')
 
     def test_include_test_sources_flag_is_honoured(self):
         path = 'checks/src/test/java/CheckTest.java'
@@ -621,14 +707,128 @@ class TestMainCli(DetectorTestCase):
         outputs, _ = self.run_main('--include-test-sources', 'true')
         self.assertEqual(outputs['rule-props-changed'], 'true')
 
-    def test_bad_diff_range_exits_with_an_error_annotation(self):
+    def test_bad_diff_range_is_undetermined(self):
         self.write('a.txt', '1\n')
         self.commit('only commit')
-        stderr = StringIO()
-        with redirect_stderr(stderr), self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(UndeterminedError) as ctx:
             detect(str(self.repo), 'no-such-ref', 'HEAD', RULESET, False)
-        self.assertEqual(ctx.exception.code, 1)
-        self.assertIn('::error::', stderr.getvalue())
+        self.assertEqual(ctx.exception.severity, 'error')
+
+
+class TestFailSafeFallback(DetectorTestCase):
+    """
+    Whenever the comparison cannot be made, the answer must be "changed".
+
+    Under-reporting is the expensive direction: a rule property change reaching SQC unannounced
+    is a production surprise, while a spurious "Yes" costs one manual check. So every one of
+    these paths reports true, annotates why, and still exits 0 -- a non-zero exit would write no
+    outputs at all, which the workflow reads as "unchanged".
+    """
+
+    def run_main(self, *extra_args):
+        argv = ['detect_rule_props_changed.py', '--repo', str(self.repo), *extra_args]
+        stdout, stderr = StringIO(), StringIO()
+        with patch.object(sys, 'argv', argv), redirect_stdout(stdout), redirect_stderr(stderr):
+            main()  # must not raise, including SystemExit
+        outputs = dict(line.split('=', 1) for line in stdout.getvalue().strip().splitlines())
+        return outputs, stderr.getvalue()
+
+    def assertAssumedChanged(self, outputs, severity='warning', stderr=''):
+        self.assertEqual(outputs['rule-props-changed'], 'true')
+        self.assertEqual(outputs['detection-status'], 'assumed-changed')
+        self.assertEqual(outputs['base-ref'], '')
+        self.assertEqual(outputs['match-count'], '0')
+        if stderr:
+            self.assertIn(f'::{severity}::', stderr)
+
+    def test_no_baseline_tag_assumes_changed(self):
+        """A first release has nothing to compare against, so it cannot claim "unchanged"."""
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+
+        outputs, err = self.run_main()
+        self.assertAssumedChanged(outputs, 'warning', err)
+
+    def test_rerun_without_an_earlier_release_assumes_changed(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        git(self.repo, 'tag', '1.0.0.100')
+
+        outputs, err = self.run_main()
+        self.assertAssumedChanged(outputs, 'warning', err)
+
+    def test_unresolvable_base_ref_assumes_changed(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+
+        outputs, err = self.run_main('--base-ref', 'no-such-tag')
+        self.assertAssumedChanged(outputs, 'error', err)
+
+    def test_unresolvable_head_ref_assumes_changed(self):
+        self.write('a.txt', '1\n')
+        self.commit('only commit')
+        self.tag_baseline()
+
+        outputs, err = self.run_main('--head-ref', 'no-such-branch')
+        self.assertAssumedChanged(outputs, 'error', err)
+
+    def test_directory_that_is_not_a_repository_assumes_changed(self):
+        with TemporaryDirectory() as plain_dir:
+            self.repo = Path(plain_dir)
+            outputs, err = self.run_main()
+        self.assertAssumedChanged(outputs, 'error', err)
+
+    def test_invalid_extra_pattern_assumes_changed(self):
+        path = 'checks/src/main/java/Check.java'
+        self.write(path, JAVA_CHECK)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write('README.md', 'unrelated\n')
+        self.commit()
+
+        outputs, err = self.run_main('--extra-patterns', '*.scala::([unclosed')
+        self.assertAssumedChanged(outputs, 'error', err)
+
+    def test_missing_git_binary_assumes_changed(self):
+        self.write('a.txt', '1\n')
+        self.commit('baseline')
+        self.tag_baseline()
+
+        with patch('detect_rule_props_changed.subprocess.run',
+                   side_effect=OSError('No such file or directory: git')):
+            outputs, err = self.run_main()
+
+        self.assertAssumedChanged(outputs, 'error', err)
+
+    def test_unexpected_exception_assumes_changed(self):
+        """The last resort: a bug in the matcher must not answer "unchanged" by crashing."""
+        self.write('a.txt', '1\n')
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write('a.txt', '2\n')
+        self.commit()
+
+        with patch('detect_rule_props_changed.detect',
+                   side_effect=RuntimeError('matcher blew up')):
+            outputs, err = self.run_main()
+
+        self.assertAssumedChanged(outputs, 'error', err)
+        self.assertIn('Traceback', err)
+
+    def test_a_successful_detection_is_not_marked_as_assumed(self):
+        """The guard rails must not fire on the happy path."""
+        path = 'checks/src/main/java/Check.java'
+        self.write(path, JAVA_CHECK)
+        self.commit('baseline')
+        self.tag_baseline()
+        self.write(path, JAVA_CHECK.replace('key = "format"', 'key = "pattern"'))
+        self.commit()
+
+        outputs, err = self.run_main()
+        self.assertEqual(outputs['rule-props-changed'], 'true')
+        self.assertEqual(outputs['detection-status'], 'detected')
+        self.assertNotIn('::warning::', err)
+        self.assertNotIn('::error::', err)
 
 
 class TestRuleset(unittest.TestCase):

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -53,7 +53,7 @@ This workflow composes several actions from this repository:
 | `pm-email`                   | Product manager email to assign the release ticket after technical release                                      | Yes      | -            |
 | `release-automation-secret-name` | Secret name used to create analyzer update PRs. If omitted, defaults to `sonar-{plugin-name}-release-automation`. | No       | -            |
 | `short-description`          | Brief summary for release and integration tickets                                                               | Yes      | -            |
-| `rule-props-changed`         | Whether rule properties changed (`true`/`false`); mapped to Yes/No in the release ticket                        | Yes      | -            |
+| `rule-props-changed`         | **Deprecated, no-op.** Detected automatically (see [Rule property detection](#rule-property-detection)); any value passed is ignored | No       | -            |
 | `branch`                     | Branch to release from                                                                                          | Yes      | `master`     |
 | `release-notes`              | Explicit release notes; if empty, Jira release notes are generated                                              | No       | -            |
 | `sq-ide-short-description`   | Short summary of SQ IDE related changes                                                                         | No       | -            |
@@ -131,7 +131,6 @@ jobs:
       plugin-name: "csd"
       pm-email: "pm@example.com"
       short-description: ${{ inputs.short-description }}
-      rule-props-changed: "false"
       branch: "master"
       new-version: ${{ inputs.new-version }}
       sqs-integration: true
@@ -161,6 +160,25 @@ jobs:
   the release-lock gate (see below) guards against this.
 - When `release-notes` is empty, Jira release notes are fetched and used.
 - Integration tickets and analyzer update PRs are created only if their respective flags are enabled and prerequisites are met.
+
+### Rule property detection
+
+The *Rule Properties Changed* field on the release ticket (`customfield_11263`, see SC-4654) is
+computed during `prepare-release` by the
+[detect-rule-props-changed](../detect-rule-props-changed/README.md) action. It diffs the previous
+release tag — the nearest tag reachable from the release commit — against the commit being
+released, and looks for changed rule property declarations. Recognised conventions cover
+`@RuleProperty` (Java/Kotlin), `new RuleParameter(` (sonar-swift, sonar-dart),
+`[RuleParameter(` (sonar-dotnet-enterprise) and SonarJS `config.ts` fields.
+
+The `rule-props-changed` input is therefore no longer needed and is ignored. It is still declared
+so that callers still passing it keep working — GitHub fails a reusable-workflow call that passes
+an undeclared input — and it will be removed once the caller repositories have dropped it. Remove
+the line from your caller workflow whenever convenient.
+
+If a repository declares rule properties in a way the action does not recognise, the detection can
+be extended per repository via the action's `extra-patterns` input. When no tag is reachable from
+the release commit (a first release), the action warns and reports `No`.
 - Summaries:
   - Each job includes a "Summary" step that writes to `$GITHUB_STEP_SUMMARY` only when `verbose: true`.
   - A short release announcement containing the project, released version, and GitHub release-notes link is sent to `#team-code-quality-pm-em-lead` by default after the GitHub release is created. Set `code-quality-leads-slack-notification: false` to opt out.

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -169,7 +169,8 @@ computed during `prepare-release` by the
 release tag — the nearest tag reachable from the release commit — against the commit being
 released, and looks for changed rule property declarations. Recognised conventions cover
 `@RuleProperty` (Java/Kotlin), `new RuleParameter(` (sonar-swift, sonar-dart),
-`[RuleParameter(` (sonar-dotnet-enterprise) and SonarJS `config.ts` fields.
+`[RuleParameter(` (sonar-dotnet-enterprise) and SonarJS `config.ts` fields. Deleting a check class
+counts as a change too, since its rule properties go with it.
 
 The `rule-props-changed` input is therefore no longer needed and is ignored. It is still declared
 so that callers still passing it keep working — GitHub fails a reusable-workflow call that passes

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -177,8 +177,13 @@ an undeclared input — and it will be removed once the caller repositories have
 the line from your caller workflow whenever convenient.
 
 If a repository declares rule properties in a way the action does not recognise, the detection can
-be extended per repository via the action's `extra-patterns` input. When no tag is reachable from
-the release commit (a first release), the action warns and reports `No`.
+be extended per repository via the action's `extra-patterns` input.
+
+Detection is **fail-safe**: whenever the comparison cannot be made — a first release with no tag
+to compare against, a shallow checkout, a git failure, a detection step that does not run at all —
+the ticket gets `Yes`, never `No`, and the job summary marks the value as *assumed* rather than
+detected. An undetected rule property change reaching SQC is far more expensive than a `Yes` that
+turns out to be unnecessary. Only an explicit `false` from the detector produces `No`.
 - Summaries:
   - Each job includes a "Summary" step that writes to `$GITHUB_STEP_SUMMARY` only when `verbose: true`.
   - A short release announcement containing the project, released version, and GitHub release-notes link is sent to `#team-code-quality-pm-em-lead` by default after the GitHub release is created. Set `code-quality-leads-slack-notification: false` to opt out.


### PR DESCRIPTION
Part of 
<!-- 
  Only for standalone PRs without Jira issue in the PR title: 
    * Replace this comment with Epic ID to create a new Maintenance ticket in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Maintenance ticket in Jira without a parent 
-->

----
## Summary by Gitar

- **New GitHub Action:**
    - Added `detect-rule-props-changed` action to automatically detect rule property changes against the previous release tag.
- **Workflow & Documentation Updates:**
    - Integrated rule property detection into `automated-release.yml` and deprecated the manual `rule-props-changed` workflow input.

<sub>This will update automatically on new commits.</sub>