### PR TITLE
GHA-404 Surface failing releasability check(s) in own job summary

### DIFF
--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -368,7 +368,7 @@ jobs:
           version: ${{ steps.get-version.outputs.release-version }}
 
       - name: Summary
-        if: ${{ always() && inputs.verbose }}
+        if: ${{ always() && (inputs.verbose || steps.releasability.outcome != 'success') }}
         shell: bash
         env:
           BRANCH: ${{ inputs.branch }}

--- a/.okf/log.md
+++ b/.okf/log.md
@@ -1,5 +1,14 @@
 # Update Log
 
+## 2026-08-14
+* **Releasability failure detail in summary**: The `check-releasability` job's `Summary` step now
+  runs on any failure, not only when `verbose: true` — so its per-check ✅/❌ breakdown (e.g.
+  `QA`, `Jira`, `QualityGate`) is always visible in that job's own step-summary section on the
+  run's summary page, right alongside the top-level `summarize-release` message. Just an `if:`
+  condition change; no new job outputs or cross-job plumbing. Partially resolves
+  [unhelpful-failure-summary](/risks/unhelpful-failure-summary.md) — scoped to the releasability
+  case only; the other eight jobs in the DAG are unchanged.
+
 ## 2026-07-23
 * **Automated release Slack visibility**: After creating a GitHub release, the analyzer release
   workflow now sends a short project/version/release-notes announcement to the private Code

--- a/.okf/risks/unhelpful-failure-summary.md
+++ b/.okf/risks/unhelpful-failure-summary.md
@@ -22,6 +22,20 @@ per-job `RESULT_*` values are already collected and then thrown away into a sing
   the recovery runbook from [no idempotency](/risks/no-idempotency.md).
 - Replace "re-run as needed" with idempotency-aware guidance.
 
+# Partial resolution (2026-08-14)
+
+The `check-releasability` case is fixed, minimally: its `Summary` step now runs whenever
+`verbose` is true *or* the releasability action didn't succeed (not only when `verbose` is
+true), so the per-check ✅/❌ breakdown (e.g. `QA`, `Jira`, `QualityGate`) that step already
+printed is now visible on every failure, not just when `verbose` was explicitly requested. No
+job-output plumbing to `summarize-release` was needed for this — GitHub's run-summary page
+already stacks every job's step summary together, so this section shows up next to
+`summarize-release`'s message without any wiring. See
+[automated-release § Releasability failure detail](/workflows/automated-release.md).
+`summarize-release`'s own top-level message is unchanged and still generic; the other eight jobs
+in the DAG have no equivalent step summary at all — the broader per-job checklist recommendation
+above remains open.
+
 # Citations
 
 [1] [docs/ARCHITECTURE_REVIEW.md § 5.1](/../docs/ARCHITECTURE_REVIEW.md)

--- a/.okf/workflows/automated-release.md
+++ b/.okf/workflows/automated-release.md
@@ -95,6 +95,17 @@ Outputs: `new-version` (Jira version name), `sqaa-pull-request-url`.
 - This workflow has been the subject of an [architecture review](/decisions/architecture-review-2026-07.md)
   identifying reliability, testability, and observability gaps — see the
   [risks](/risks/index.md) directory.
+- **Releasability failure detail**: the `check-releasability` job's own `Summary` step runs
+  whenever `verbose` is true *or* the releasability action didn't succeed — not only when
+  `verbose` is true — so the ✅/❌ per-check breakdown (e.g. `QA`, `Jira`, `QualityGate`) always
+  appears in that job's own step-summary section on failure, without needing `verbose`. Since the
+  GitHub Actions run-summary page stacks every job's step summary in one place, this section is
+  visible right alongside `summarize-release`'s top-level message — no need to click into the job
+  or thread the data through job outputs. `summarize-release`'s own top-level message is
+  unchanged (still the generic "One or more jobs failed" line on any failure). This narrowly
+  addresses the releasability case of
+  [unhelpful-failure-summary](/risks/unhelpful-failure-summary.md); the other eight jobs still
+  have no verbose-independent step summary at all.
 - The `automated-release-run` Claude Code skill (`.claude/skills/automated-release-run/`) is the
   recommended way to trigger a release: it checks releasability, interviews for
   `workflow_dispatch` inputs, triggers the run, then polls and merges the bump-version, SQS, and

--- a/docs/AUTOMATED_RELEASE.md
+++ b/docs/AUTOMATED_RELEASE.md
@@ -146,6 +146,7 @@ jobs:
   - Execute a releasability check on the specified branch immediately after freezing (using `SonarSource/gh-action_releasability@v3`)
   - Update the commit status with the latest releasability results
   - Fail early if the releasability check does not pass, preventing unnecessary work (like creating REL tickets)
+  - Name the specific failing sub-check(s) (e.g. `QA`, `Jira`, `QualityGate`) in the Check Releasability job's own step summary, on any failure (not only when `verbose: true`)
 - When `freeze-branch: true`, the workflow will:
   - Lock the specified branch at the start of the release
   - Proceed with the release steps


### PR DESCRIPTION
## Summary
- The `check-releasability` job's `Summary` step now also runs when the releasability action didn't succeed, not only when `verbose: true` — so its existing ✅/❌ per-check breakdown (e.g. `QA`, `Jira`, `QualityGate`) is visible on every failure instead of only when `verbose` was explicitly requested.
- No new job outputs or cross-job plumbing needed: GitHub's run-summary page already stacks every job's step summary on one page, so this section now shows up right there without extra clicks.
- Updated the `.okf` knowledge bundle and `docs/AUTOMATED_RELEASE.md` to describe the new behavior.

## Test plan
- [ ] Validated YAML syntax and hand-traced the `if:` condition against all four verbose/outcome combinations (success+verbose, success+non-verbose, failure+verbose, failure+non-verbose) — confirmed the step only skips when verbose is off and the check succeeded.
- [ ] Confirm CI is green on this PR.